### PR TITLE
Fix SQLite compatibility for user riding preferences

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -112,7 +112,10 @@ class User(UserMixin, db.Model):
         'QuestSubmission', backref='submitter', lazy='dynamic',
         cascade='all, delete-orphan'
     )
-    riding_preferences = db.Column(ARRAY(TEXT), nullable=True, default=list)
+    # Use a JSON column so that the tests can run on SQLite which does not
+    # support the PostgreSQL ARRAY type used in production. JSON gracefully
+    # degrades to TEXT storage on SQLite while preserving list semantics.
+    riding_preferences = db.Column(db.JSON, nullable=True, default=list)
     ride_description = db.Column(db.String(500), nullable=True)
     bike_picture = db.Column(db.String(200), nullable=True)
     bike_description = db.Column(db.String(500), nullable=True)


### PR DESCRIPTION
## Summary
- use JSON for `riding_preferences` so SQLite can run tests

## Testing
- `pytest tests/test_auth.py::test_get_login_opens_modal -q`

------
https://chatgpt.com/codex/tasks/task_e_68418083dedc832bb61d75ab3d8ca852