### PR TITLE
Fix list column handling in Postgres

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -737,7 +737,7 @@ def edit_profile(user_id):
     except Exception as exc:
         db.session.rollback()
         logger.error('Exception occurred: %s', exc)
-        return
+        return jsonify({'error': 'Internal server error'}), 500
 
 
 @main_bp.route('/profile/<int:user_id>/edit-bike', methods=['POST'])
@@ -767,13 +767,13 @@ def edit_bike(user_id):
         except Exception as exc:
             db.session.rollback()
             logger.error('Exception occurred: %s', exc)
-            return
+            return jsonify({'error': 'Internal server error'}), 500
 
     logger.debug('Bike form validation failed.')
     for field, errors in bike_form.errors.items():
         for error in errors:
             logger.debug('Error in the %s field - %s', field, error)
-    return
+    return jsonify({'error': 'Invalid form submission'}), 400
 
 
 @main_bp.route('/pin_message/<int:game_id>/<int:message_id>', methods=['POST'])

--- a/app/models.py
+++ b/app/models.py
@@ -112,10 +112,14 @@ class User(UserMixin, db.Model):
         'QuestSubmission', backref='submitter', lazy='dynamic',
         cascade='all, delete-orphan'
     )
-    # Use a JSON column so that the tests can run on SQLite which does not
-    # support the PostgreSQL ARRAY type used in production. JSON gracefully
-    # degrades to TEXT storage on SQLite while preserving list semantics.
-    riding_preferences = db.Column(db.JSON, nullable=True, default=list)
+    # Use an ARRAY column in PostgreSQL but fall back to JSON for other
+    # backends (e.g. SQLite during tests). ``with_variant`` allows SQLAlchemy
+    # to use the appropriate type per dialect.
+    riding_preferences = db.Column(
+        db.JSON().with_variant(ARRAY(TEXT), "postgresql"),
+        nullable=True,
+        default=list,
+    )
     ride_description = db.Column(db.String(500), nullable=True)
     bike_picture = db.Column(db.String(200), nullable=True)
     bike_description = db.Column(db.String(500), nullable=True)


### PR DESCRIPTION
## Summary
- use ARRAY for `riding_preferences` in Postgres
- return JSON errors from profile editing views

## Testing
- `poetry install`
- `poetry run pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841d855f80c832ba26166d8dc1ae789