### PR TITLE
Add sponsors modal link to navbar

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -223,6 +223,11 @@
                     <a href="javascript:void(0)" class="btn btn-primary btn-lg" onclick="openModal('registerModal')">Register Today!</a>
                 </li>
               {% endif %}
+              <li class="nav-item">
+                  <a class="nav-link" href="javascript:void(0)" onclick="openModal('sponsorsModal', '{{ selected_game_id }}')">
+                      <i class="fas fa-handshake me-1"></i>Game Sponsors
+                  </a>
+              </li>
           </ul>
       </div>
   </div>


### PR DESCRIPTION
## Summary
- show a `Game Sponsors` modal link in the navigation bar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68427a72ecb8832b860d2759a35d1330