### PR TITLE
Allow optional comment for photo verification

### DIFF
--- a/app/quests.py
+++ b/app/quests.py
@@ -240,7 +240,7 @@ def submit_quest(quest_id):
     if verification_type == "photo_comment" and (not image_file or image_file.filename == ""):
         return jsonify({
             "success": False,
-            "message": "Both photo and comment are required for verification"
+            "message": "Photo required for verification"
         }), 400
     if quest.verification_type == "Pause":
         return jsonify({"success": False, "message": "This quest is currently paused"}), 403

--- a/app/static/js/quest_detail_modal.js
+++ b/app/static/js/quest_detail_modal.js
@@ -109,7 +109,7 @@ function populateQuestDetails(quest, userCompletionCount, canVerify, questId, ne
     }
     switch (quest.verification_type) {
         case 'photo_comment':
-            elements['modalQuestVerificationType'].innerText = "Must upload a photo and a comment to earn points!";
+            elements['modalQuestVerificationType'].innerText = "Must upload a photo to earn points! Comment optional.";
             break;
         case 'photo':
             elements['modalQuestVerificationType'].innerText = "Must upload a photo to earn points!";
@@ -251,9 +251,9 @@ function getVerificationFormHTML(verificationType) {
                  class="epic-input" accept="image/*" required>
         </div>
         <div class="form-group">
-          <label for="verificationComment" class="epic-label">Enter a Comment</label>
+          <label for="verificationComment" class="epic-label">Enter a Comment (optional)</label>
           <textarea id="verificationComment" name="verificationComment"
-                    class="epic-textarea" placeholder="Enter a comment..." required></textarea>
+                    class="epic-textarea" placeholder="Enter a comment..."></textarea>
         </div>
         <div class="form-group">
           <button type="submit">Submit Verification</button>

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -81,7 +81,7 @@ The dashboard is your central hub for accessing games, quests, and community fea
 Quests can have different verification methods:
 - **Photo Verification**: Upload a photo as evidence of quest completion.
 - **Comment Verification**: Provide a comment describing how you completed the quest.
-- **Photo and Comment Verification**: Both upload a photo and provide a comment.
+- **Photo and Comment Verification**: Upload a photo with an optional comment.
 
 ### Quest Submissions
 


### PR DESCRIPTION
## Summary
- allow `photo_comment` submissions without a comment
- show "comment optional" hints in quest detail modal
- update user guide for optional comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427b7515c4832b8f83ed7bb23c69d2