### PR TITLE
Fix TWA config optional

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -115,7 +115,7 @@ def create_app(config_overrides=None):
         "FACEBOOK_PAGE_ID": inscopeconfig["social"]["facebook_page_id"],
         "INSTAGRAM_ACCESS_TOKEN": inscopeconfig["social"]["instagram_access_token"],
         "INSTAGRAM_USER_ID": inscopeconfig["social"]["instagram_user_id"],
-        "TWA_SHA256_FINGERPRINT": inscopeconfig["twa"]["SHA256_CERT_FINGERPRINT"],
+        "TWA_SHA256_FINGERPRINT": inscopeconfig.get("twa", {}).get("SHA256_CERT_FINGERPRINT", ""),
 
         "DEFAULT_SUPER_ADMIN_USERNAME": inscopeconfig["encryption"]["DEFAULT_SUPER_ADMIN_USERNAME"],
         "DEFAULT_SUPER_ADMIN_PASSWORD": inscopeconfig["encryption"]["DEFAULT_SUPER_ADMIN_PASSWORD"],

--- a/app/config.py
+++ b/app/config.py
@@ -161,6 +161,13 @@ def load_config():
             "instagram_access_token": _get_env("INSTAGRAM_ACCESS_TOKEN", _toml_config["social"]["instagram_access_token"]),
             "instagram_user_id": _get_env("INSTAGRAM_USER_ID", _toml_config["social"]["instagram_user_id"]),
         },
+
+        "twa": {
+            "SHA256_CERT_FINGERPRINT": _get_env(
+                "TWA_SHA256_FINGERPRINT",
+                _toml_config.get("twa", {}).get("SHA256_CERT_FINGERPRINT", ""),
+            ),
+        },
  
         # -----------------------------------------------------------------------------
         # 6. Safely read the sqlalchemy_engine_options section or fall back to defaults


### PR DESCRIPTION
## Summary
- look up TWA fingerprint in the configuration loader
- guard against missing TWA config in the Flask app factory

## Testing
- `poetry install`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_login')*

------
https://chatgpt.com/codex/tasks/task_e_6842bc72b37c832b852544a399ad48f7