### PR TITLE
Fix image URL handling for submissions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -876,6 +876,13 @@ def resize_image():
         return jsonify({'error': "Invalid request: Missing 'path' or 'width'"}), 400
 
     try:
+        # Normalize the image path. Stored paths may or may not include the
+        # leading "static/" segment. The resize endpoint expects paths relative
+        # to the static folder.
+        image_path = image_path.lstrip('/')
+        if image_path.startswith('static/'):
+            image_path = image_path[len('static/'):] 
+
         full_image_path = os.path.abspath(os.path.join(current_app.static_folder, image_path))
         if not full_image_path.startswith(os.path.abspath(current_app.static_folder)):
             current_app.logger.error("Attempted path traversal detected: %s", image_path)

--- a/app/utils.py
+++ b/app/utils.py
@@ -249,6 +249,25 @@ def public_media_url(path):
     """Return a publicly accessible URL for a stored media path."""
     if not path:
         return None
+
+    # Already an absolute URL
+    if path.startswith(('http://', 'https://')):
+        return path
+
+    # Paths may be stored with or without the leading "static/" segment
+    # and may include a leading slash. Handle these variants to avoid
+    # generating URLs like "/static//images/..." or duplicating the
+    # "static" prefix.
+
+    if path.startswith('/static/'):
+        return path
+
+    # Remove any leading slash before further checks
+    path = path.lstrip('/')
+
+    if path.startswith('static/'):
+        path = path[len('static/') :]
+
     return url_for('static', filename=path)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+from flask import url_for
+
+from app import create_app
+from app.utils import public_media_url
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+    ctx.pop()
+
+
+def test_public_media_url_variants(app):
+    # absolute URL should be returned as-is
+    assert public_media_url("https://example.com/img.jpg") == "https://example.com/img.jpg"
+
+    # already served from /static should be returned unchanged
+    assert public_media_url("/static/images/foo.jpg") == "/static/images/foo.jpg"
+
+    # stored with leading 'static/' prefix
+    expect = url_for("static", filename="images/foo.jpg")
+    assert public_media_url("static/images/foo.jpg") == expect
+
+    # stored with leading slash only
+    assert public_media_url("/images/foo.jpg") == expect
+
+    # stored without slash or static prefix
+    assert public_media_url("images/foo.jpg") == expect


### PR DESCRIPTION
## Summary
- avoid doubling `/static/` when building media URLs
- add regression tests for `public_media_url`

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c7660140832bbf0b2d0a2c3aff66