### PR TITLE
Fallback liaison email

### DIFF
--- a/app/games.py
+++ b/app/games.py
@@ -215,10 +215,10 @@ def send_liaison_email(game_id):
         flash('Access denied: Only administrators can send liaison emails.', 'danger')
         return redirect(url_for('main.index'))
 
-    if send_social_media_liaison_email(game_id):
+    if send_social_media_liaison_email(game_id, fallback_to_last=True):
         flash('Liaison email sent successfully.', 'success')
     else:
-        flash('No new submissions to email or sending failed.', 'info')
+        flash('No submissions available to email.', 'info')
 
     return redirect(url_for('games.update_game', game_id=game_id))
 


### PR DESCRIPTION
## Summary
- add fallback option in `send_social_media_liaison_email`
- allow admin button to resend recent submissions

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d5bc3b68832bb14d4e1de71446bb