### PR TITLE
Filter liaison emails by upload settings

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -861,9 +861,11 @@ def send_social_media_liaison_email(
         submissions = (
             QuestSubmission.query
             .join(Quest, Quest.id == QuestSubmission.quest_id)
+            .join(User, User.id == QuestSubmission.user_id)
             .filter(
                 Quest.game_id == game_id,
-                QuestSubmission.timestamp > cutoff_time
+                QuestSubmission.timestamp > cutoff_time,
+                User.upload_to_socials.is_(True),
             )
             .order_by(QuestSubmission.timestamp.asc())  # Chronological order (oldest first)
             .all()
@@ -882,7 +884,11 @@ def send_social_media_liaison_email(
             submissions = (
                 QuestSubmission.query
                 .join(Quest, Quest.id == QuestSubmission.quest_id)
-                .filter(Quest.game_id == game_id)
+                .join(User, User.id == QuestSubmission.user_id)
+                .filter(
+                    Quest.game_id == game_id,
+                    User.upload_to_socials.is_(True),
+                )
                 .order_by(QuestSubmission.timestamp.desc())
                 .limit(last_limit)
                 .all()

--- a/tests/test_liaison_email.py
+++ b/tests/test_liaison_email.py
@@ -1,0 +1,71 @@
+import pytest
+from datetime import datetime, timedelta
+from pytz import utc
+
+from app import create_app, db
+from app.models import Game, Quest, User, QuestSubmission
+from app.utils import send_social_media_liaison_email
+
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "MAIL_SERVER": None,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+def test_liaison_email_respects_upload_to_socials(app, monkeypatch):
+    captured = {}
+
+    def fake_send_email(to, subject, html_content, inline_images=None):
+        captured["html"] = html_content
+        return True
+
+    monkeypatch.setattr("app.utils.send_email", fake_send_email)
+
+    with app.app_context():
+        admin = User(username="admin", email="admin@example.com", license_agreed=True)
+        admin.set_password("pw")
+        db.session.add(admin)
+        db.session.commit()
+
+        game = Game(
+            title="Test Game",
+            start_date=datetime.now(utc) - timedelta(days=1),
+            end_date=datetime.now(utc) + timedelta(days=1),
+            admin_id=admin.id,
+            social_media_liaison_email="liaison@example.com",
+        )
+        db.session.add(game)
+        db.session.commit()
+
+        quest = Quest(title="Quest 1", points=1, game=game)
+        db.session.add(quest)
+        db.session.commit()
+
+        sharer = User(username="sharer", email="s@example.com", license_agreed=True, upload_to_socials=True)
+        sharer.set_password("pw")
+        nonsharer = User(username="private", email="p@example.com", license_agreed=True, upload_to_socials=False)
+        nonsharer.set_password("pw")
+        db.session.add_all([sharer, nonsharer])
+        db.session.commit()
+
+        sub1 = QuestSubmission(quest_id=quest.id, user_id=sharer.id, timestamp=datetime.now(utc))
+        sub2 = QuestSubmission(quest_id=quest.id, user_id=nonsharer.id, timestamp=datetime.now(utc))
+        db.session.add_all([sub1, sub2])
+        db.session.commit()
+
+        assert send_social_media_liaison_email(game.id)
+        html = captured.get("html", "")
+        assert "sharer" in html
+        assert "private" not in html


### PR DESCRIPTION
## Summary
- respect user upload_to_socials flag when collecting submissions for liaison emails
- add regression test to ensure submissions from users who disable sharing are excluded

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842dacf28bc832b9369cba8c14db454