### PR TITLE
Fix quest creation access control

### DIFF
--- a/app/templates/manage_quests.html
+++ b/app/templates/manage_quests.html
@@ -80,7 +80,8 @@
             method: 'POST',
             body: formData,
             headers: {
-                'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                'Accept': 'application/json'
             },
         })
         .then(response => response.json())


### PR DESCRIPTION
## Summary
- restrict quest creation routes to administrator users
- support AJAX quest creation requests via JSON responses

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842e11838c4832bb9a13d363ac3a6b0