### PR TITLE
Hide incomplete quests with no badge

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -193,6 +193,9 @@ def _prepare_quests(game, user_id, user_quests, now):
     activities = pinned_messages + (unpinned_messages + [ut for ut in completed_quests if ut.quest.game_id == game.id])
     activities.sort(key=get_datetime, reverse=True)
 
+    # Filter out quests with no badge and no submissions
+    quests = [q for q in quests if not (q.badge_id is None and q.total_completions == 0)]
+
     quests.sort(key=lambda x: (-x.is_sponsored, -x.personal_completions, -x.total_completions))
     return quests, activities
 

--- a/tests/test_quest_display.py
+++ b/tests/test_quest_display.py
@@ -1,0 +1,58 @@
+import pytest
+from datetime import datetime, timedelta
+from pytz import utc
+
+from app import create_app, db
+from app.models import Game, User, Quest, QuestSubmission, Badge
+from app.main import _prepare_quests
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "MAIL_SERVER": None,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+def test_prepare_quests_hides_unbadged_empty(app):
+    with app.app_context():
+        admin = User(username="admin", email="admin@example.com", license_agreed=True)
+        admin.set_password("pw")
+        db.session.add(admin)
+        db.session.commit()
+
+        game = Game(
+            title="Test Game",
+            start_date=datetime.now(utc) - timedelta(days=1),
+            end_date=datetime.now(utc) + timedelta(days=1),
+            admin_id=admin.id,
+        )
+        db.session.add(game)
+        db.session.commit()
+
+        badge = Badge(name="B")
+        db.session.add(badge)
+        db.session.commit()
+
+        q1 = Quest(title="q1", game=game)
+        q2 = Quest(title="q2", game=game, badge_id=badge.id)
+        db.session.add_all([q1, q2])
+        db.session.commit()
+
+        sub = QuestSubmission(quest_id=q2.id, user_id=admin.id)
+        db.session.add(sub)
+        db.session.commit()
+
+        quests, _ = _prepare_quests(game, admin.id, [], datetime.now(utc))
+        ids = [q.id for q in quests]
+        assert q1.id not in ids
+        assert q2.id in ids


### PR DESCRIPTION
## Summary
- hide quests with no badge and no submissions from the index page
- test quest visibility logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e68b5810832bb8e4992d7e6f61dc