### PR TITLE
Hide incomplete quests with badge missing image

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -193,6 +193,18 @@ def _prepare_quests(game, user_id, user_quests, now):
     activities = pinned_messages + (unpinned_messages + [ut for ut in completed_quests if ut.quest.game_id == game.id])
     activities.sort(key=get_datetime, reverse=True)
 
+    # Filter out quests lacking a valid badge and with no submissions
+    quests = [
+        q for q in quests
+        if not (
+            (
+                q.badge_id is None
+                or (q.badge is not None and not q.badge.image)
+            )
+            and q.total_completions == 0
+        )
+    ]
+
     quests.sort(key=lambda x: (-x.is_sponsored, -x.personal_completions, -x.total_completions))
     return quests, activities
 
@@ -203,7 +215,11 @@ def _prepare_user_data(game_id, profile):
         Badge.query
              .options(joinedload(Badge.quests))   # eager-load the quests relationship
              .join(Quest)
-             .filter(Quest.game_id == game_id, Quest.badge_id.isnot(None))
+             .filter(
+                 Quest.game_id == game_id,
+                 Quest.badge_id.isnot(None),
+                 Badge.image.isnot(None)
+             )
              .distinct()
              .all()
     )

--- a/tests/test_quest_display.py
+++ b/tests/test_quest_display.py
@@ -1,0 +1,128 @@
+import pytest
+from datetime import datetime, timedelta
+from pytz import utc
+
+from app import create_app, db
+from app.models import Game, User, Quest, QuestSubmission, Badge
+from app.main import _prepare_quests, _prepare_user_data
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "MAIL_SERVER": None,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+def test_prepare_quests_hides_unbadged_empty(app):
+    with app.app_context():
+        admin = User(username="admin", email="admin@example.com", license_agreed=True)
+        admin.set_password("pw")
+        db.session.add(admin)
+        db.session.commit()
+
+        game = Game(
+            title="Test Game",
+            start_date=datetime.now(utc) - timedelta(days=1),
+            end_date=datetime.now(utc) + timedelta(days=1),
+            admin_id=admin.id,
+        )
+        db.session.add(game)
+        db.session.commit()
+
+        badge = Badge(name="B")
+        db.session.add(badge)
+        db.session.commit()
+
+        q1 = Quest(title="q1", game=game)
+        q2 = Quest(title="q2", game=game, badge_id=badge.id)
+        db.session.add_all([q1, q2])
+        db.session.commit()
+
+        sub = QuestSubmission(quest_id=q2.id, user_id=admin.id)
+        db.session.add(sub)
+        db.session.commit()
+
+        quests, _ = _prepare_quests(game, admin.id, [], datetime.now(utc))
+        ids = [q.id for q in quests]
+        assert q1.id not in ids
+        assert q2.id in ids
+
+
+def test_prepare_quests_hides_badgeless_image(app):
+    with app.app_context():
+        admin = User(username="admin2", email="admin2@example.com", license_agreed=True)
+        admin.set_password("pw")
+        db.session.add(admin)
+        db.session.commit()
+
+        game = Game(
+            title="Test Game2",
+            start_date=datetime.now(utc) - timedelta(days=1),
+            end_date=datetime.now(utc) + timedelta(days=1),
+            admin_id=admin.id,
+        )
+        db.session.add(game)
+        db.session.commit()
+
+        b_no_img = Badge(name="B1")
+        b_img = Badge(name="B2", image="img.png")
+        db.session.add_all([b_no_img, b_img])
+        db.session.commit()
+
+        q1 = Quest(title="q1", game=game, badge_id=b_no_img.id)
+        q2 = Quest(title="q2", game=game, badge_id=b_img.id)
+        q3 = Quest(title="q3", game=game, badge_id=b_no_img.id)
+        db.session.add_all([q1, q2, q3])
+        db.session.commit()
+
+        sub = QuestSubmission(quest_id=q3.id, user_id=admin.id)
+        db.session.add(sub)
+        db.session.commit()
+
+        quests, _ = _prepare_quests(game, admin.id, [], datetime.now(utc))
+        ids = [q.id for q in quests]
+        assert q1.id not in ids
+        assert q2.id in ids
+        assert q3.id in ids
+
+
+def test_prepare_user_data_hides_badgeless_image(app):
+    with app.app_context():
+        admin = User(username="admin3", email="admin3@example.com", license_agreed=True)
+        admin.set_password("pw")
+        db.session.add(admin)
+        db.session.commit()
+
+        game = Game(
+            title="Test Game3",
+            start_date=datetime.now(utc) - timedelta(days=1),
+            end_date=datetime.now(utc) + timedelta(days=1),
+            admin_id=admin.id,
+        )
+        db.session.add(game)
+        db.session.commit()
+
+        b_no_img = Badge(name="B1")
+        b_img = Badge(name="B2", image="img.png")
+        db.session.add_all([b_no_img, b_img])
+        db.session.commit()
+
+        q1 = Quest(title="q1", game=game, badge_id=b_no_img.id)
+        q2 = Quest(title="q2", game=game, badge_id=b_img.id)
+        db.session.add_all([q1, q2])
+        db.session.commit()
+
+        earned, unearned = _prepare_user_data(game.id, admin)
+        all_badges = [b['id'] for b in earned + unearned]
+        assert b_no_img.id not in all_badges
+        assert b_img.id in all_badges


### PR DESCRIPTION
## Summary
- skip quests with badges that lack images when they have no submissions
- do not show badges without images in the index page
- expand quest display tests for these cases

## Testing
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e68b5810832bb8e4992d7e6f61dc