### PR TITLE
Fix quest submissions failing after video update

### DIFF
--- a/app/quests.py
+++ b/app/quests.py
@@ -226,9 +226,6 @@ def submit_quest(quest_id):
             "message": f"You cannot submit this quest again until {next_eligible_time}"
         }), 403
 
-    sid = request.form.get("sid")
-    if not sid:
-        return jsonify({"success": False, "message": "No session ID provided"}), 400
 
     verification_type = quest.verification_type
     image_file = request.files.get("image")
@@ -237,8 +234,7 @@ def submit_quest(quest_id):
 
     # Debug logging of incoming files and parameters
     current_app.logger.debug(
-        "submit_quest called: sid=%s, verification_type=%s, image_file=%s, video_file=%s",
-        sid,
+        "submit_quest called: verification_type=%s, image_file=%s, video_file=%s",
         verification_type,
         getattr(image_file, "filename", None),
         getattr(video_file, "filename", None),
@@ -297,7 +293,7 @@ def submit_quest(quest_id):
         twitter_url, fb_url, instagram_url = (None, None, None)
         if image_url and current_user.upload_to_socials:
             twitter_url, fb_url, instagram_url = post_to_social_media(
-                image_url, image_path, status_text, game, sid
+                image_url, image_path, status_text, game
             )
 
         # Hybrid cross-post: Post to Mastodon if the user is linked.
@@ -778,10 +774,6 @@ def submit_photo(quest_id):
             message = f"You cannot submit this quest again until {next_eligible_time}."
             return jsonify({"success": False, "message": message}), 400
 
-        sid = request.form.get("sid")
-        if not sid:
-            return jsonify({"success": False, "message": "No session ID provided"}), 400
-
         photo = request.files.get("photo")
         video = request.files.get("video")
 
@@ -815,7 +807,7 @@ def submit_photo(quest_id):
         twitter_url, fb_url, instagram_url = (None, None, None)
         if image_url and current_user.upload_to_socials:
             twitter_url, fb_url, instagram_url = post_to_social_media(
-                image_url, media_path, status_text, game, sid
+                image_url, media_path, status_text, game
             )
 
         # Post to Mastodon if the user is linked.

--- a/app/social.py
+++ b/app/social.py
@@ -6,7 +6,7 @@ import json
 import mimetypes
 
 
-def post_to_social_media(image_url, image_path, status, game, sid):
+def post_to_social_media(image_url, image_path, status, game):
     twitter_url, fb_url, instagram_url = None, None, None
 
     if game.twitter_api_key and game.twitter_api_secret and game.twitter_access_token and game.twitter_access_token_secret:


### PR DESCRIPTION
## Summary
- remove obsolete `sid` parameter from social posting
- drop session ID checks in quest submission routes
- clean up debug logging

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446c8293c8832b826db1d633dc4023