### PR TITLE
Fix ffmpeg missing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ QuestByCycle is a Flask-based web application designed to engage and motivate th
 - Python 3.11+
 - PostgreSQL
 - git
+- ffmpeg (for video processing)
 -
 
 ### Debian 12 Server Setup
@@ -135,6 +136,7 @@ QuestByCycle is a Flask-based web application designed to engage and motivate th
 14. Configure
     - Copy `config.toml.example` to `config.toml` and adjust the variables accordingly.
     - Copy `gunicorn.conf.py.example` to `gunicorn.conf.py` and adjust the variables accordingly.
+    - Ensure the `ffmpeg` binary is installed and accessible or set `FFMPEG_PATH` in `config.toml`.
 
 15. Run the server in debug
 ```sudo -u APPUSER /home/APPUSER/.local/bin/poetry run flask   --app wsgi:app   run   --host=127.0.0.1   --port=5000```

--- a/app/config.py
+++ b/app/config.py
@@ -82,6 +82,7 @@ def load_config():
             "BADGE_IMAGE_DIR": _get_env("BADGE_IMAGE_DIR", _toml_config["main"]["BADGE_IMAGE_DIR"]),
             "TASKCSV": _get_env("TASKCSV", _toml_config["main"]["TASKCSV"]),
             "LOCAL_DOMAIN": _get_env("LOCAL_DOMAIN", _toml_config["main"]["LOCAL_DOMAIN"]),
+            "FFMPEG_PATH": _get_env("FFMPEG_PATH", _toml_config["main"].get("FFMPEG_PATH", "ffmpeg")),
         },
         "encryption": {
             "DEFAULT_SUPER_ADMIN_USERNAME": _get_env(

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,7 @@
 import uuid
 import os
 import subprocess
+import shutil
 import csv
 import io
 import bleach
@@ -227,9 +228,16 @@ def save_submission_video(submission_video_file):
         final_name = secure_filename(f"{uuid.uuid4()}.mp4")
         final_path = os.path.join(uploads_dir, final_name)
 
+        # determine ffmpeg binary
+        ffmpeg_bin = current_app.config.get('FFMPEG_PATH') or shutil.which('ffmpeg')
+        if not ffmpeg_bin or (not os.path.isabs(ffmpeg_bin) and shutil.which(ffmpeg_bin) is None):
+            raise FileNotFoundError(
+                "ffmpeg executable not found. Install ffmpeg or set FFMPEG_PATH"
+            )
+
         # run ffmpeg to compress and scale
         ffmpeg_cmd = [
-            'ffmpeg', '-i', orig_path,
+            ffmpeg_bin, '-i', orig_path,
             '-vf', "scale='min(1280,iw)':-2",
             '-c:v', 'libx264', '-preset', 'fast', '-crf', '28',
             '-c:a', 'aac', '-movflags', 'faststart',

--- a/config.toml.example
+++ b/config.toml.example
@@ -5,6 +5,7 @@ SQLALCHEMY_ECHO = false
 BADGE_IMAGE_DIR = "badge_images"
 TASKCSV = "csv"
 LOCAL_DOMAIN = "localhost:5000"
+FFMPEG_PATH = "ffmpeg"
 
 [encryption]
 DEFAULT_SUPER_ADMIN_PASSWORD = "test"

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -95,6 +95,7 @@ Ensure you have the following installed:
 - Python 3.x
 - PostgreSQL
 - Virtualenv
+- ffmpeg
 
 ### Installation
 


### PR DESCRIPTION
## Summary
- allow specifying FFMPEG_PATH in config
- handle missing ffmpeg gracefully when saving videos
- document ffmpeg requirement in README and DEVELOPER docs
- add FFMPEG_PATH example in `config.toml.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844751eecf8832ba0d04fbad66bedcc