### PR TITLE
Fix invalid video upload error handling

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -254,7 +254,9 @@ def save_submission_video(submission_video_file):
         except subprocess.CalledProcessError as e:
             stderr_output = e.stderr.decode(errors="ignore") if e.stderr else ""
             current_app.logger.error("ffmpeg failed: %s", stderr_output)
-            raise
+            os.remove(orig_path)
+            current_app.logger.debug("Removed temporary upload %s", orig_path)
+            raise ValueError("Invalid or corrupted video file") from e
 
         # cleanup original upload
         os.remove(orig_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,3 +32,16 @@ def test_public_media_url_variants(app):
 
     # stored without slash or static prefix
     assert public_media_url("images/foo.jpg") == expect
+
+
+def test_save_submission_video_invalid(app, tmp_path):
+    """Uploading an invalid video should raise a ValueError."""
+    from io import BytesIO
+    from werkzeug.datastructures import FileStorage
+    from app.utils import save_submission_video
+
+    fake_video = BytesIO(b"not a real video")
+    file = FileStorage(stream=fake_video, filename="bad.mp4", content_type="video/mp4")
+
+    with pytest.raises(ValueError):
+        save_submission_video(file)


### PR DESCRIPTION
## Summary
- refine `save_submission_video` error handling so ffmpeg failures raise `ValueError`
- remove temporary upload when ffmpeg fails
- add regression test for invalid video upload

## Testing
- `PYTHONPATH=$PWD pytest tests/test_utils.py::test_save_submission_video_invalid -q`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684480314970832b8e55448094de989d