### PR TITLE
Fix first-load update popup

### DIFF
--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -76,16 +76,20 @@ self.addEventListener("activate", (event) => {
   event.waitUntil(
     (async () => {
       const cacheKeys = await caches.keys();
+      let isUpdate = false;
       await Promise.all(
         cacheKeys.map((key) => {
           if (key !== CACHE_NAME) {
             console.log(`Deleting old cache: ${key}`);
+            isUpdate = true;
             return caches.delete(key);
           }
         })
       );
       await clients.claim();
-      notifyClientsAboutUpdate();
+      if (isUpdate) {
+        notifyClientsAboutUpdate();
+      }
     })()
   );
 });


### PR DESCRIPTION
## Summary
- only show update popup if previous cache exists

## Testing
- `poetry install`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684558fe9250832ba45a5592f76a2365