### PR TITLE
Fix quest modal refresh

### DIFF
--- a/app/static/js/quest_detail_modal.js
+++ b/app/static/js/quest_detail_modal.js
@@ -50,6 +50,38 @@ function openQuestDetailModal(questId) {
     });
 }
 
+function refreshQuestDetailModal(questId) {
+  fetch(`/quests/detail/${questId}/user_completion`, { credentials: 'same-origin' })
+    .then(r => r.json())
+    .then(data => {
+      const { quest, userCompletion, canVerify, nextEligibleTime } = data;
+      if (
+        !populateQuestDetails(
+          quest,
+          userCompletion.completions,
+          canVerify,
+          questId,
+          nextEligibleTime
+        )
+      ) {
+        console.error('populateQuestDetails – required element missing');
+        return;
+      }
+
+      ensureDynamicElementsExistAndPopulate(
+        quest,
+        userCompletion.completions,
+        nextEligibleTime,
+        canVerify
+      );
+
+      fetchSubmissions(questId);
+    })
+    .catch(err => {
+      console.error('Failed to refresh quest detail modal:', err);
+    });
+}
+
 
 function lazyLoadImages() {
     const images = document.querySelectorAll('img.lazyload');
@@ -404,7 +436,7 @@ async function submitQuestDetails(event, questId) {
     updateScoreboard(data.total_points);
     updateSocialLinks(data);
 
-    openQuestDetailModal(questId);
+    refreshQuestDetailModal(questId);
     event.target.reset();
   } catch (err) {
     console.error('Submission error:', err);


### PR DESCRIPTION
## Summary
- keep quest modal open when submitting verifications
- dynamically refresh quest details and submissions

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684580d489dc832b968e374eff2f2b75