### PR TITLE
Fix upload file validation

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -342,7 +342,12 @@ class QuestSubmissionForm(FlaskForm):
 
 class PhotoForm(FlaskForm):
     """Form for photo uploads."""
-    photo = FileField(validators=[DataRequired()])
+    photo = FileField(
+        validators=[
+            DataRequired(),
+            FileAllowed(["jpg", "jpeg", "png", "mp4", "webm", "mov"], "Images or videos only!")
+        ]
+    )
 
 
 class ShoutBoardForm(FlaskForm):

--- a/app/games.py
+++ b/app/games.py
@@ -15,7 +15,7 @@ from app.forms import GameForm
 from app.utils import (
     save_leaderboard_image,
     generate_smoggy_images,
-    allowed_file,
+    allowed_image_file,
     send_social_media_liaison_email,
 )
 from io import BytesIO
@@ -102,7 +102,7 @@ def create_game():
         )
         if 'leaderboard_image' in request.files:
             image_file = request.files['leaderboard_image']
-            if image_file and allowed_file(image_file.filename):
+            if image_file and allowed_image_file(image_file.filename):
                 try:
                     filename = save_leaderboard_image(image_file)
                     game.leaderboard_image = filename
@@ -173,7 +173,7 @@ def update_game(game_id):
         if ('leaderboard_image' in request.files and
                 request.files['leaderboard_image'].filename):
             image_file = request.files['leaderboard_image']
-            if image_file and allowed_file(image_file.filename):
+            if image_file and allowed_image_file(image_file.filename):
                 try:
                     filename = save_leaderboard_image(image_file)
                     game.leaderboard_image = filename

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,3 +45,16 @@ def test_save_submission_video_invalid(app, tmp_path):
 
     with pytest.raises(ValueError):
         save_submission_video(file)
+
+
+def test_save_submission_image_invalid_extension(app, tmp_path):
+    """Uploading a non-image file should raise a ValueError."""
+    from io import BytesIO
+    from werkzeug.datastructures import FileStorage
+    from app.utils import save_submission_image
+
+    fake_file = BytesIO(b"{}")
+    file = FileStorage(stream=fake_file, filename="bad.json", content_type="application/json")
+
+    with pytest.raises(ValueError):
+        save_submission_image(file)


### PR DESCRIPTION
## Summary
- enforce allowed file extensions for media uploads
- update game admin upload checks
- restrict PhotoForm uploads to image/video
- test rejection of invalid image extensions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845841b8ef0832b9e24f0544d2e83aa