### PR TITLE
Add mobile-web-app meta tag

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -13,6 +13,7 @@
 
   <!-- Required for Safari to recognize the PWA -->
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="QuestByCycle">
 


### PR DESCRIPTION
## Summary
- update HTML layout to include `mobile-web-app-capable` meta tag for modern PWA support

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845847643ec832bb66798b49c8c11ee