### PR TITLE
Fix password field autocomplete

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -51,7 +51,7 @@ class CSRFProtectForm(FlaskForm):
 class RegistrationForm(FlaskForm):
     """User registration form."""
     email = StringField("Email", validators=[DataRequired(), Email()])
-    password = PasswordField("Password", validators=[DataRequired()])
+    password = PasswordField("Password", validators=[DataRequired()], render_kw={"autocomplete": "new-password"})
     confirm_password = PasswordField(
         "Confirm Password",
         validators=[
@@ -61,6 +61,7 @@ class RegistrationForm(FlaskForm):
                 message="Passwords must match."
             )
         ],
+        render_kw={"autocomplete": "new-password"},
     )
     accept_license = BooleanField("I agree to the ", validators=[DataRequired()])
     submit = SubmitField("Register")
@@ -80,7 +81,11 @@ class MastodonLoginForm(FlaskForm):
 class LoginForm(FlaskForm):
     """User login form."""
     email = StringField("Email", validators=[DataRequired(), Email()])
-    password = PasswordField("Password", validators=[DataRequired()])
+    password = PasswordField(
+        "Password",
+        validators=[DataRequired()],
+        render_kw={"autocomplete": "current-password"},
+    )
     remember_me = BooleanField("Remember Me", default=True)
     submit = SubmitField("Sign In")
 
@@ -98,19 +103,35 @@ class ForgotPasswordForm(FlaskForm):
 
 class UpdatePasswordForm(FlaskForm):
     """Update password form."""
-    current_password = PasswordField("Current Password", validators=[DataRequired()])
-    new_password = PasswordField("New Password", validators=[DataRequired(), Length(min=8)])
+    current_password = PasswordField(
+        "Current Password",
+        validators=[DataRequired()],
+        render_kw={"autocomplete": "current-password"},
+    )
+    new_password = PasswordField(
+        "New Password",
+        validators=[DataRequired(), Length(min=8)],
+        render_kw={"autocomplete": "new-password"},
+    )
     confirm_password = PasswordField(
-        "Confirm New Password", validators=[DataRequired(), EqualTo("new_password")]
+        "Confirm New Password",
+        validators=[DataRequired(), EqualTo("new_password")],
+        render_kw={"autocomplete": "new-password"},
     )
     submit = SubmitField("Update Password")
 
 
 class ResetPasswordForm(FlaskForm):
     """Reset password form."""
-    password = PasswordField("New Password", validators=[DataRequired()])
+    password = PasswordField(
+        "New Password",
+        validators=[DataRequired()],
+        render_kw={"autocomplete": "new-password"},
+    )
     confirm_password = PasswordField(
-        "Confirm Password", validators=[DataRequired(), EqualTo("password")]
+        "Confirm Password",
+        validators=[DataRequired(), EqualTo("password")],
+        render_kw={"autocomplete": "new-password"},
     )
     submit = SubmitField("Reset Password")
 
@@ -119,7 +140,11 @@ class AddUserForm(FlaskForm):
     """Add a new user (admin functionality)."""
     username = StringField("Username", validators=[DataRequired()])
     email = StringField("Email", validators=[DataRequired(), Email()])
-    password = PasswordField("Password", validators=[DataRequired()])
+    password = PasswordField(
+        "Password",
+        validators=[DataRequired()],
+        render_kw={"autocomplete": "new-password"},
+    )
     submit = SubmitField("Add User")
 
 

--- a/app/static/js/register_modal.js
+++ b/app/static/js/register_modal.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
     <div class="alert alert-info">This email is already registered. Enter your password to log in.</div>  
     <div class="form-group">  
       <label for="existingUserPassword">Password</label>  
-      <input type="password" id="existingUserPassword" class="form-control">  
+      <input type="password" id="existingUserPassword" class="form-control" autocomplete="current-password">
       <div id="loginError" class="text-danger mt-1" style="display: none;"></div>  
     </div>  
     <div class="form-group">  


### PR DESCRIPTION
## Summary
- add autocomplete attributes for password inputs in forms
- ensure JS-created login field also sets autocomplete

## Testing
- `poetry export -f requirements.txt --without-hashes | pip install --quiet -r /dev/stdin`
- `export PYTHONPATH=$PWD`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845849daa1c832b9e7b616f3f8ef62e