### PR TITLE
Fix duplicate password id

### DIFF
--- a/app/templates/modals/login_modal.html
+++ b/app/templates/modals/login_modal.html
@@ -35,7 +35,7 @@
 
         <div class="form-group">
           {{ login_form.password.label }}
-          {{ login_form.password(class="form-control") }}
+          {{ login_form.password(class="form-control", id="loginPassword") }}
           {% for err in login_form.password.errors %}
             <span style="color: red;">[{{ err }}]</span>
           {% endfor %}

--- a/app/templates/modals/register_modal.html
+++ b/app/templates/modals/register_modal.html
@@ -39,7 +39,7 @@
   
           <div class="form-group">
             {{ register_form.password.label }}
-            {{ register_form.password(class="form-control") }}
+            {{ register_form.password(class="form-control", id="registerPassword") }}
             {% for err in register_form.password.errors %}
               <span style="color: red;">[{{ err }}]</span>
             {% endfor %}


### PR DESCRIPTION
## Summary
- assign unique IDs to login and registration password fields to avoid DOM conflicts

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684584a79dc4832b8a91469f214927bc