### PR TITLE
Fix duplicate id attributes

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -121,7 +121,7 @@
                                                                                         game_id=selected_game_id,
                                                                                         message_id=activity.id) }}"
                                                                     method="post">
-                                                                    {{ form.hidden_tag() }}
+                                                                    {{ form.csrf_token }}
                                                                     <button type="submit" class="blue_button">
                                                                         {{ 'Unpin' if activity.is_pinned else 'Pin' }}
                                                                     </button>
@@ -168,7 +168,7 @@
                                                                                     game_id=selected_game_id,
                                                                                     message_id=activity.id) }}"
                                                                 method="post">
-                                                                {{ form.hidden_tag() }}
+                                                                {{ form.csrf_token }}
                                                                 <button type="submit" class="blue_button">
                                                                     {{ 'Unpin' if activity.is_pinned else 'Pin' }}
                                                                 </button>


### PR DESCRIPTION
## Summary
- replace `form.hidden_tag()` with `form.csrf_token` in two admin pin/unpin forms to avoid duplicate `game_id` IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684584b6b938832ba77ff1881234d568