### PR TITLE
Fix quest instructions length

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -138,7 +138,7 @@ class GameForm(FlaskForm):
         "Game Description", validators=[DataRequired(), Length(max=1000)]
     )
     description2 = StringField(
-        "Quest Rules", validators=[DataRequired(), Length(max=1000)]
+        "Quest Rules", validators=[DataRequired(), Length(max=4500)]
     )
     start_date = DateField("Start Date", format="%Y-%m-%d", validators=[DataRequired()])
     end_date = DateField("End Date", format="%Y-%m-%d", validators=[DataRequired()])

--- a/app/models.py
+++ b/app/models.py
@@ -374,7 +374,7 @@ class Game(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(250), nullable=False)
     description = db.Column(db.String(1000))
-    description2 = db.Column(db.String(1000))
+    description2 = db.Column(db.String(4500))
     start_date = db.Column(
         DateTime(timezone=True),           # ← make it timezone-aware
         nullable=False,


### PR DESCRIPTION
## Summary
- allow longer Quest Instructions text when creating games

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684585946a24832b8ab82dd2a0e9eed2