### PR TITLE
Fix import of allowed_file in badges module

### DIFF
--- a/app/badges.py
+++ b/app/badges.py
@@ -7,7 +7,8 @@ import csv
 from flask import Blueprint, current_app, render_template, flash, redirect, url_for, jsonify, request
 from flask_login import login_required, current_user
 from .forms import BadgeForm
-from .utils import save_badge_image, allowed_file
+# ``allowed_file`` is defined below for validating uploads
+from .utils import save_badge_image
 from .models import db, Quest, Badge, UserQuest, Game
 from werkzeug.utils import secure_filename
 


### PR DESCRIPTION
## Summary
- fix import of `allowed_file` to avoid ImportError and rely on local helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458edd256c832b97032e8115dcf8ae