### PR TITLE
Fix invalid session user_id crash

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -174,7 +174,11 @@ def create_app(config_overrides=None):
     @login_manager.user_loader
     def load_user(user_id):
         from app.models import User
-        return User.query.get(int(user_id))
+        try:
+            return User.query.get(int(user_id))
+        except (TypeError, ValueError):
+            logger.error("Invalid user_id in session: %s", user_id)
+            return None
 
     @app.errorhandler(404)
     def not_found_error(error):


### PR DESCRIPTION
## Summary
- guard user loader from invalid session IDs

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845be3204f4832bb3aed93d30586021