### PR TITLE
Add HEIF support for image uploads

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -58,7 +58,10 @@ def sanitize_html(html_content):
 
 # Allowed extensions for image and video uploads
 MAX_POINTS_INT = 2**63 - 1
-ALLOWED_IMAGE_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp'}
+# Include common formats plus HEIF/HEIC for modern mobile devices
+ALLOWED_IMAGE_EXTENSIONS = {
+    'png', 'jpg', 'jpeg', 'gif', 'webp', 'heif', 'heic'
+}
 ALLOWED_VIDEO_EXTENSIONS = {'mp4', 'webm', 'mov'}
 # Videos are limited to 10 MB for uploads
 MAX_VIDEO_BYTES = 10 * 1024 * 1024

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -80,6 +80,7 @@ The dashboard is your central hub for accessing games, quests, and community fea
 
 Quests can have different verification methods:
 - **Photo Verification**: Upload a photo as evidence of quest completion.
+- **Supported Image Formats**: PNG, JPG/JPEG, GIF, WebP, and HEIF/HEIC.
 - **Comment Verification**: Provide a comment describing how you completed the quest.
 - **Photo and Comment Verification**: Both upload a photo and provide a comment.
 - **Video Verification**: Upload a short video as evidence, optionally with a comment. Videos are automatically compressed to stay under 10&nbsp;MB.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 from flask import url_for
 
 from app import create_app
-from app.utils import public_media_url
+from app.utils import public_media_url, allowed_image_file
 
 @pytest.fixture
 def app():
@@ -58,3 +58,9 @@ def test_save_submission_image_invalid_extension(app, tmp_path):
 
     with pytest.raises(ValueError):
         save_submission_image(file)
+
+
+def test_allowed_image_file_heif():
+    """HEIF and HEIC images should be recognized as valid."""
+    assert allowed_image_file("photo.heif")
+    assert allowed_image_file("image.HEIC")


### PR DESCRIPTION
## Summary
- allow HEIF/HEIC files in `ALLOWED_IMAGE_EXTENSIONS`
- document supported image formats in `USER.md`
- test HEIF extension handling

## Testing
- `PYTHONPATH=. poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845cade7e70832b884687738cb3efea