### PR TITLE
Add delete button in submission modal

### DIFF
--- a/app/static/js/submission_detail_modal.js
+++ b/app/static/js/submission_detail_modal.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const me      = Number(modal.dataset.currentUserId);
     const isOwner = Number(image.user_id) === me;
+    const isAdmin = modal.dataset.isAdmin === 'True' || modal.dataset.isAdmin === 'true';
 
 
     // ── NEW: grab your photo-edit controls ──
@@ -17,9 +18,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const photoInput        = $('#submissionPhotoInput');
     const savePhotoBtn      = $('#savePhotoBtn');
     const cancelPhotoBtn    = $('#cancelPhotoBtn');
+    const deleteBtn         = $('#deleteSubmissionBtn');
 
-    // show/hide the “Change Photo” button
+    // show/hide the “Change Photo” button and delete button
     editPhotoBtn.hidden      = !isOwner;
+    deleteBtn.hidden         = !(isOwner || isAdmin);
     photoEditControls.hidden = true;
 
     // wire the click to reveal the file picker
@@ -33,6 +36,23 @@ document.addEventListener('DOMContentLoaded', () => {
       photoInput.value         = '';
       photoEditControls.hidden = true;
       editPhotoBtn.hidden      = false;
+    });
+
+    // delete the submission with confirmation
+    deleteBtn.addEventListener('click', () => {
+      if (!confirm('Are you sure you want to delete this submission?')) return;
+      const id = modal.dataset.submissionId;
+      fetch(`/quests/quest/delete_submission/${id}`, {
+        method: 'DELETE',
+        headers: { 'X-CSRF-Token': csrf() }
+      })
+        .then(r => r.json())
+        .then(j => {
+          if (!j.success) throw new Error(j.message || 'Delete failed');
+          closeModal('submissionDetailModal');
+          alert('Submission deleted successfully.');
+        })
+        .catch(e => alert('Error deleting submission: ' + e.message));
     });
 
     // save → upload to server

--- a/app/templates/modals/submission_detail_modal.html
+++ b/app/templates/modals/submission_detail_modal.html
@@ -1,4 +1,4 @@
-<div id="submissionDetailModal" class="modal" data-current-user-id="{{ current_user.id }}">
+<div id="submissionDetailModal" class="modal" data-current-user-id="{{ current_user.id }}" data-is-admin="{{ current_user.is_admin }}">
   <div class="modal-content">
 
     <!-- ── TOP BAR: Submitted by + Like + Close ── -->
@@ -44,6 +44,9 @@
       </video>
       <button id="editPhotoBtn" class="btn btn-outline-secondary btn-sm mt-2" hidden>
         Change Photo
+      </button>
+      <button id="deleteSubmissionBtn" class="btn btn-danger btn-sm mt-2 ms-2" hidden>
+        Delete
       </button>
 
       <!-- hidden file-picker + controls -->


### PR DESCRIPTION
## Summary
- allow admins and owners to delete a submission from the detail modal
- show confirmation prompt before deletion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845cbe04e68832bad13d6c91d8aad4c