### PR TITLE
Fix game name endpoint access

### DIFF
--- a/app/games.py
+++ b/app/games.py
@@ -480,7 +480,6 @@ def generate_qr_for_game(game_id):
 
 
 @games_bp.route('/get_game/<int:game_id>', methods=['GET'])
-@login_required
 def get_game(game_id):
     """
     Retrieve the game with the given game_id and return its title as JSON.


### PR DESCRIPTION
## Summary
- remove `login_required` on `get_game` route so the homepage can fetch game titles without authentication

## Testing
- `poetry install`
- `PYTHONPATH=. poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ce655998832bb879e75fce82415e