### PR TITLE
Fix badge endpoint fetch

### DIFF
--- a/app/static/js/badge_management.js
+++ b/app/static/js/badge_management.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function loadBadges() {
-    fetch('/badges/badges')
+    fetch('/badges')
         .then(response => response.json())
         .then(data => {
             const badgesBody = document.getElementById('badgesBody');

--- a/app/static/js/badge_modal.js
+++ b/app/static/js/badge_modal.js
@@ -4,13 +4,13 @@
 window.allBadges = window.allBadges || [];
 
 /**
- * Load all badges from the server endpoint (/badges/badges) if not already cached.
+ * Load all badges from the server endpoint (/badges) if not already cached.
  * Calls the provided callback with the badge array.
  */
 function loadAllBadges(callback) {
   const gameHolder = document.getElementById("game_IdHolder");
   const selectedGameId = gameHolder ? gameHolder.getAttribute("data-game-id") : null;
-  let fetchUrl = '/badges/badges';
+  let fetchUrl = '/badges';
   if (selectedGameId && !isNaN(parseInt(selectedGameId,10)) && selectedGameId !== "0") {
     fetchUrl += `?game_id=${selectedGameId}`;
   }

--- a/app/templates/manage_quests.html
+++ b/app/templates/manage_quests.html
@@ -65,7 +65,7 @@
 
     async function loadBadges() {
         try {
-            const response = await fetch('/badges/badges');
+            const response = await fetch('/badges');
             if (!response.ok) throw new Error('Failed to fetch badges');
             const data = await response.json();
             badges = data.badges || [];


### PR DESCRIPTION
## Summary
- use `/badges` endpoint when loading badge data

## Testing
- `PYTHONPATH=. pytest tests/test_auth.py::test_post_invalid_email[False] -q` *(fails: Got /, expected to start with /?show_login=1)*

------
https://chatgpt.com/codex/tasks/task_e_6845ce35386c832b99f994f0d944e2b7