### PR TITLE
Ensure likes and comments removed with submission

### DIFF
--- a/app/quests.py
+++ b/app/quests.py
@@ -956,6 +956,10 @@ def delete_submission(submission_id):
         check_and_revoke_badges(submission.user_id, game_id=quest.game_id)
         db.session.commit()
 
+    # Explicitly remove likes and replies so they do not linger
+    SubmissionLike.query.filter_by(submission_id=submission.id).delete()
+    SubmissionReply.query.filter_by(submission_id=submission.id).delete()
+
     db.session.delete(submission)
     db.session.commit()
     return jsonify({"success": True})

--- a/app/static/js/submission_detail_modal.js
+++ b/app/static/js/submission_detail_modal.js
@@ -50,6 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(j => {
           if (!j.success) throw new Error(j.message || 'Delete failed');
           closeModal('submissionDetailModal');
+          resetModalContent();
           alert('Submission deleted successfully.');
         })
         .catch(e => alert('Error deleting submission: ' + e.message));


### PR DESCRIPTION
## Summary
- remove all submission likes and replies in `delete_submission`
- reset the submission detail modal after deleting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845d23709cc832ba0ee4f1150f83667