### PR TITLE
Add per-game admin assignment support

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -189,8 +189,9 @@ class GameForm(FlaskForm):
     custom_game_code = StringField("Custom Game Code", validators=[Optional()])
     is_public = BooleanField("Public Game", default=True)
     allow_joins = BooleanField("Allow Joining", default=True)
-    social_media_liaison_email = StringField("Social Media Liaison Email",   
-                                            validators=[Optional(), Email()])  
+    admins = SelectMultipleField("Game Admins", coerce=int)
+    social_media_liaison_email = StringField("Social Media Liaison Email",
+                                            validators=[Optional(), Email()])
     social_media_email_frequency = SelectField(  
         "Email Frequency",  
         choices=[  

--- a/app/quests.py
+++ b/app/quests.py
@@ -110,7 +110,7 @@ def manage_game_quests(game_id):
     """
     game = Game.query.get_or_404(game_id)
 
-    if not current_user.is_admin:
+    if not current_user.is_admin_for_game(game_id):
         flash("Access denied: Only administrators can manage quests.", "danger")
         return redirect(url_for("main.index", game_id=game_id))
 
@@ -131,7 +131,7 @@ def manage_game_quests(game_id):
 def add_quest(game_id):
     """Add a new quest to the game."""
 
-    if not current_user.is_admin:
+    if not current_user.is_admin_for_game(game_id):
         flash("Access denied: Only administrators can add quests.", "danger")
         return redirect(url_for("main.index", game_id=game_id))
 
@@ -424,10 +424,10 @@ def delete_quest(quest_id):
     Args:
         quest_id (int): The ID of the quest to delete.
     """
-    if not current_user.is_admin:
-        return jsonify({"success": False, "message": "Permission denied"}), 403
-
     quest_to_delete = Quest.query.get_or_404(quest_id)
+    game_id = quest_to_delete.game_id
+    if not current_user.is_admin_for_game(game_id):
+        return jsonify({"success": False, "message": "Permission denied"}), 403
     db.session.delete(quest_to_delete)
 
     try:
@@ -1046,7 +1046,7 @@ def delete_all_quests(game_id):
     """
     game = Game.query.get_or_404(game_id)
 
-    if game.admin_id != current_user.id:
+    if not current_user.is_admin_for_game(game_id):
         return (
             jsonify(
                 {
@@ -1077,7 +1077,7 @@ def get_game_title(game_id):
     """
     game = Game.query.get_or_404(game_id)
 
-    if game.admin_id != current_user.id:
+    if not current_user.is_admin_for_game(game_id):
         return jsonify(
             {"success": False, "message": "You do not have permission to view this game."}
         ), 403

--- a/app/templates/create_game.html
+++ b/app/templates/create_game.html
@@ -104,6 +104,10 @@
             <label class="form-check-label" for="allow_joins">Allow Joining</label>
         </div>
         <div class="form-group">
+            <label for="admins">Game Admins</label>
+            {{ form.admins(class_="form-control", id="admins", multiple=True) }}
+        </div>
+        <div class="form-group">
             <label for="custom_game_code">Custom Game Code</label>
             <input type="text" class="form-control" id="custom_game_code" name="custom_game_code" value="{{ form.custom_game_code.data }}" readonly>
         </div>

--- a/app/templates/update_game.html
+++ b/app/templates/update_game.html
@@ -65,6 +65,10 @@
             <label class="form-check-label" for="allow_joins">Allow Joining</label>
         </div>
         <div class="form-group">
+            <label for="admins">Game Admins</label>
+            {{ form.admins(class_="form-control", id="admins", multiple=True) }}
+        </div>
+        <div class="form-group">
             <label for="custom_game_code">Custom Game Code</label>
             <input type="text" class="form-control" id="custom_game_code" name="custom_game_code" value="{{ form.custom_game_code.data }}" readonly>
         </div>

--- a/app/utils.py
+++ b/app/utils.py
@@ -778,6 +778,9 @@ def generate_demo_game():
         leaderboard_image="leaderboard_image.png"  # Assuming the image is stored in the static folder
     )
     db.session.add(demo_game)
+    admin_user = User.query.get(1)
+    if admin_user:
+        demo_game.admins.append(admin_user)
     db.session.commit()
 
     # Import quests and badges for the demo game

--- a/tests/test_liaison_email.py
+++ b/tests/test_liaison_email.py
@@ -47,6 +47,7 @@ def test_liaison_email_lists_all_submissions(app, monkeypatch):
             social_media_liaison_email="liaison@example.com",
         )
         db.session.add(game)
+        game.admins.append(admin)
         db.session.commit()
 
         quest = Quest(title="Quest 1", points=1, game=game)

--- a/tests/test_manage_quests_logic.py
+++ b/tests/test_manage_quests_logic.py
@@ -53,18 +53,21 @@ def login_as(client, user):
 
 
 def create_game(title, admin_id):
-    return Game(
+    game = Game(
         title=title,
         start_date=datetime.now(utc) - timedelta(days=1),
         end_date=datetime.now(utc) + timedelta(days=1),
         admin_id=admin_id,
     )
+    return game
 
 
 def test_get_quests_per_game(client, admin_user):
     # create two games with different quests
     game1 = create_game("Game 1", admin_user.id)
     game2 = create_game("Game 2", admin_user.id)
+    game1.admins.append(admin_user)
+    game2.admins.append(admin_user)
     db.session.add_all([game1, game2])
     db.session.commit()
 
@@ -90,6 +93,7 @@ def test_get_quests_per_game(client, admin_user):
 
 def test_manage_page_requires_admin(client, admin_user):
     game = create_game("Game", admin_user.id)
+    game.admins.append(admin_user)
     db.session.add(game)
     db.session.commit()
 

--- a/tests/test_quest_display.py
+++ b/tests/test_quest_display.py
@@ -38,6 +38,7 @@ def test_prepare_quests_hides_unbadged_empty(app):
             admin_id=admin.id,
         )
         db.session.add(game)
+        game.admins.append(admin)
         db.session.commit()
 
         badge = Badge(name="B")
@@ -73,6 +74,7 @@ def test_prepare_quests_hides_badgeless_image(app):
             admin_id=admin.id,
         )
         db.session.add(game)
+        game.admins.append(admin)
         db.session.commit()
 
         b_no_img = Badge(name="B1")
@@ -111,6 +113,7 @@ def test_prepare_user_data_hides_badgeless_image(app):
             admin_id=admin.id,
         )
         db.session.add(game)
+        game.admins.append(admin)
         db.session.commit()
 
         b_no_img = Badge(name="B1")


### PR DESCRIPTION
## Summary
- add a new `game_admins` table and allow multiple admins per game
- expose a new `admins` relationship on `Game`
- add helper `is_admin_for_game` method on `User`
- update game creation/editing to select admins
- restrict game editing to assigned admins
- adjust quest endpoints to honor per-game admins
- support choosing admins in templates
- update sample data and tests for new relationship

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d0a26058832b9818631a7b107ddb