### PR TITLE
Refresh quest modal after submission delete

### DIFF
--- a/app/static/js/quest_detail_modal.js
+++ b/app/static/js/quest_detail_modal.js
@@ -512,7 +512,8 @@ async function fetchSubmissions(questId) {
         user_profile_picture: sub.user_profile_picture,
         twitter_url:         sub.twitter_url,
         fb_url:              sub.fb_url,
-        instagram_url:       sub.instagram_url
+        instagram_url:       sub.instagram_url,
+        quest_id:            questId
       }));
 
     distributeImages(gallery);

--- a/app/static/js/submission_detail_modal.js
+++ b/app/static/js/submission_detail_modal.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   window.showSubmissionDetail = function(image) {
     const modal = $('#submissionDetailModal');
     modal.dataset.submissionId = image.id;
+    modal.dataset.questId = image.quest_id || '';
 
     const me      = Number(modal.dataset.currentUserId);
     const isOwner = Number(image.user_id) === me;
@@ -51,6 +52,9 @@ document.addEventListener('DOMContentLoaded', () => {
           if (!j.success) throw new Error(j.message || 'Delete failed');
           closeModal('submissionDetailModal');
           resetModalContent();
+          if (modal.dataset.questId) {
+            refreshQuestDetailModal(modal.dataset.questId);
+          }
           alert('Submission deleted successfully.');
         })
         .catch(e => alert('Error deleting submission: ' + e.message));


### PR DESCRIPTION
## Summary
- include quest_id when fetching submissions so thumbnails know which quest they belong to
- store questId in submission modal and refresh quest detail on deletion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d596bb6c832bb51e1fa357fe5755