### PR TITLE
Fix relative path for updateMeter fetch

### DIFF
--- a/app/static/js/index_management.js
+++ b/app/static/js/index_management.js
@@ -11,7 +11,8 @@ function refreshCSRFToken() {
 setInterval(refreshCSRFToken, 900000);
 
 function updateMeter(gameId) {
-    fetch(`games/get_game_points/${gameId}`)
+    // Ensure we request the absolute endpoint and include cookies
+    fetch(`/games/get_game_points/${gameId}`, { credentials: 'same-origin' })
         .then(response => response.json())
         .then(data => {
             const totalPoints = data.total_game_points;


### PR DESCRIPTION
## Summary
- ensure the game points endpoint is fetched from an absolute path
- include cookies when requesting game points to avoid auth redirects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d68b42c8832babd3e39a4fb5a56c