### PR TITLE
Replace pytz with zoneinfo

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -14,7 +14,9 @@ from flask import (Blueprint, render_template, request, redirect, url_for, flash
 from flask_login import login_user, logout_user, login_required, current_user
 from sqlalchemy import or_
 from sqlalchemy.exc import SQLAlchemyError
-from pytz import utc
+from datetime import timezone
+
+UTC = timezone.utc
 from urllib.parse import urlparse, urljoin
 from app.models import db, User, Game
 from app.forms import (LoginForm, RegistrationForm, ForgotPasswordForm,
@@ -557,7 +559,7 @@ def register():
                 license_agreed=True,
                 email_verified=False,
                 is_admin=False,
-                created_at=datetime.now(utc),
+                created_at=datetime.now(UTC),
                 score=0)
     user.set_password(form.password.data)
     db.session.add(user)

--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,9 @@ from sqlalchemy.orm import joinedload
 from typing import Any, List
 from datetime import datetime, timedelta
 from PIL import Image, ExifTags, UnidentifiedImageError
-from pytz import utc
+from datetime import timezone
+
+UTC = timezone.utc
 from app.models import (db, Game, User, Quest, Badge, UserQuest, QuestSubmission,
                         QuestLike, ShoutBoardMessage, ProfileWallMessage,
                         user_games)
@@ -283,7 +285,7 @@ def index(game_id, quest_id, user_id):
     forgot_form = ForgotPasswordForm()
     reset_form = ResetPasswordForm()
 
-    now = datetime.now(utc)
+    now = datetime.now(UTC)
 
     if user_id is None and current_user.is_authenticated:
         user_id = current_user.id

--- a/app/models.py
+++ b/app/models.py
@@ -3,8 +3,7 @@
 import random
 import string
 import jwt
-from pytz import utc
-from datetime import datetime
+from datetime import datetime, timezone
 from time import time
 from flask import current_app  # pylint: disable=import-error
 from flask_sqlalchemy import SQLAlchemy  # pylint: disable=import-error
@@ -12,7 +11,9 @@ from flask_login import UserMixin  # pylint: disable=import-error
 from werkzeug.security import generate_password_hash, check_password_hash  # pylint: disable=import-error
 from sqlalchemy.exc import IntegrityError  # pylint: disable=import-error
 from sqlalchemy.dialects.postgresql import ARRAY, TEXT
-from sqlalchemy import DateTime 
+from sqlalchemy import DateTime
+
+UTC = timezone.utc
 
 db = SQLAlchemy()
 
@@ -27,7 +28,7 @@ user_badges = db.Table('user_badges',
 user_games = db.Table('user_games',
     db.Column('user_id', db.Integer, db.ForeignKey('user.id'), primary_key=True),
     db.Column('game_id', db.Integer, db.ForeignKey('game.id'), primary_key=True),
-    db.Column('joined_at', db.DateTime(timezone=True), default=lambda: datetime.now(utc))
+    db.Column('joined_at', db.DateTime(timezone=True), default=lambda: datetime.now(UTC))
 )
 
 game_participants = db.Table('game_participants',
@@ -74,7 +75,7 @@ class UserQuest(db.Model):
     points_awarded = db.Column(db.Integer, default=0)
     completed_at = db.Column(
         db.DateTime(timezone=True),
-        default=lambda: datetime.now(utc)
+        default=lambda: datetime.now(UTC)
     )
     quest = db.relationship("Quest", back_populates="user_quests")
 
@@ -87,7 +88,7 @@ class User(UserMixin, db.Model):
     password_hash = db.Column(db.String(512))
     is_admin = db.Column(db.Boolean, default=False)
     is_super_admin = db.Column(db.Boolean, default=False)
-    created_at = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(utc))
+    created_at = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(UTC))
     license_agreed = db.Column(db.Boolean, nullable=False)
     user_quests = db.relationship(
         'UserQuest', backref='user', lazy='dynamic',
@@ -301,7 +302,7 @@ class Notification(db.Model):
     type = db.Column(db.String, nullable=False)  # e.g. 'follow', 'submission'
     payload = db.Column(db.JSON, nullable=False)     # the raw activity or summary
     is_read = db.Column(db.Boolean, default=False)
-    timestamp = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(utc))
+    timestamp = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
     user = db.relationship('User', back_populates='notifications')
 
@@ -311,7 +312,7 @@ class UserIP(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     ip_address = db.Column(db.String(45), nullable=False)
-    timestamp = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(utc))
+    timestamp = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
     user = db.relationship('User', backref='ip_addresses')
 
@@ -320,7 +321,7 @@ class ActivityStore(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), index=True)
     json = db.Column(db.JSON, nullable=False)
-    published = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(utc), nullable=False)
+    published = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False)
 
 
 class Quest(db.Model):
@@ -390,12 +391,12 @@ class Game(db.Model):
     start_date = db.Column(
         DateTime(timezone=True),           # ← make it timezone-aware
         nullable=False,
-        default=lambda: datetime.now(utc)   # ← callable default at runtime
+        default=lambda: datetime.now(UTC)   # ← callable default at runtime
     )
     end_date = db.Column(
         DateTime(timezone=True),
         nullable=False,
-        default=lambda: datetime.now(utc)
+        default=lambda: datetime.now(UTC)
     )
     admin_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     admins = db.relationship(
@@ -436,7 +437,7 @@ class Game(db.Model):
     is_demo = db.Column(db.Boolean, default=False)
     social_media_liaison_email = db.Column(db.String(255), nullable=True)  
     social_media_email_frequency = db.Column(db.String(50), default='weekly', nullable=True)  
-    last_social_media_email_sent = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(utc), nullable=True)
+    last_social_media_email_sent = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=True)
 
     @staticmethod
     def generate_unique_code():
@@ -498,7 +499,7 @@ class ShoutBoardMessage(db.Model):
         nullable=False
     )
     timestamp = db.Column(
-        db.DateTime(timezone=True), index=True, default=lambda: datetime.now(utc)
+        db.DateTime(timezone=True), index=True, default=lambda: datetime.now(UTC)
     )
     is_pinned = db.Column(db.Boolean, default=False)
 
@@ -518,7 +519,7 @@ class QuestSubmission(db.Model):
     video_url = db.Column(db.String(500), nullable=True)
     comment = db.Column(db.String(1000), nullable=True)
     timestamp = db.Column(
-        db.DateTime(timezone=True), index=True, default=lambda: datetime.now(utc)
+        db.DateTime(timezone=True), index=True, default=lambda: datetime.now(UTC)
     )
     twitter_url = db.Column(db.String(1024), nullable=True)
     fb_url = db.Column(db.String(1024), nullable=True)
@@ -550,7 +551,7 @@ class ProfileWallMessage(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     content = db.Column(db.Text, nullable=False)
     timestamp = db.Column(
-        db.DateTime(timezone=True), default=lambda: datetime.now(utc), index=True
+        db.DateTime(timezone=True), default=lambda: datetime.now(UTC), index=True
     )
     user_id = db.Column(
         db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'),
@@ -603,7 +604,7 @@ class SubmissionLike(db.Model):
     )
     timestamp     = db.Column(
         db.DateTime(timezone=True),
-        default=lambda: datetime.now(utc),
+        default=lambda: datetime.now(UTC),
         nullable=False
     )
 
@@ -640,7 +641,7 @@ class SubmissionReply(db.Model):
     content       = db.Column(db.String(1000), nullable=False)
     timestamp     = db.Column(
         db.DateTime(timezone=True),
-        default=lambda: datetime.now(utc),
+        default=lambda: datetime.now(UTC),
         nullable=False,
         index=True
     )

--- a/app/quests.py
+++ b/app/quests.py
@@ -53,7 +53,9 @@ from .models import (
     User, UserQuest, SubmissionLike, SubmissionReply,
     Notification
 )
-from pytz import utc
+from datetime import timezone
+
+UTC = timezone.utc
 
 quests_bp = Blueprint("quests", __name__, template_folder="templates")
 
@@ -211,7 +213,7 @@ def submit_quest(quest_id):
     current_app.logger.debug("Start quest submission for quest_id=%s", quest_id)
     quest = Quest.query.get_or_404(quest_id)
     game = Game.query.get_or_404(quest.game_id)
-    now = datetime.now(utc)
+    now = datetime.now(UTC)
 
     # Check if the quest is within game dates.
     if game.start_date > now or now > game.end_date:
@@ -311,7 +313,7 @@ def submit_quest(quest_id):
             twitter_url=twitter_url,
             fb_url=fb_url,
             instagram_url=instagram_url,
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(UTC),
         )
         db.session.add(new_submission)
 
@@ -322,13 +324,13 @@ def submit_quest(quest_id):
                 quest_id=quest_id,
                 completions=1,
                 points_awarded=quest.points,
-                completed_at=datetime.now(timezone.utc),
+                completed_at=datetime.now(UTC),
             )
             db.session.add(user_quest)
         else:
             user_quest.completions += 1
             user_quest.points_awarded += quest.points
-            user_quest.completed_at = datetime.now(timezone.utc)
+            user_quest.completed_at = datetime.now(UTC)
 
         db.session.commit()
 
@@ -769,7 +771,7 @@ def submit_photo(quest_id):
     form = PhotoForm()
     quest = Quest.query.get_or_404(quest_id)
     game = Game.query.get_or_404(quest.game_id)
-    now = datetime.now(utc)
+    now = datetime.now(UTC)
 
     if not quest.enabled:
         flash("This quest is not enabled.", "error")
@@ -835,7 +837,7 @@ def submit_photo(quest_id):
             twitter_url=twitter_url,
             fb_url=fb_url,
             instagram_url=instagram_url,
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(UTC),
         )
         db.session.add(new_submission)
 
@@ -851,7 +853,7 @@ def submit_photo(quest_id):
         else:
             user_quest.completions += 1
             user_quest.points_awarded += quest.points
-            user_quest.completed_at = datetime.now(timezone.utc)
+            user_quest.completed_at = datetime.now(UTC)
 
         db.session.commit()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,7 +54,7 @@ mongodb = ["pymongo (>=3.0)"]
 redis = ["redis (>=3.0)"]
 rethinkdb = ["rethinkdb (>=2.4.0)"]
 sqlalchemy = ["sqlalchemy (>=1.4)"]
-test = ["APScheduler[etcd,mongodb,redis,rethinkdb,sqlalchemy,tornado,zookeeper]", "PySide6", "anyio (>=4.5.2)", "gevent", "pytest", "pytz", "twisted"]
+test = ["APScheduler[etcd,mongodb,redis,rethinkdb,sqlalchemy,tornado,zookeeper]", "PySide6", "anyio (>=4.5.2)", "gevent", "pytest", "twisted"]
 tornado = ["tornado (>=4.3)"]
 twisted = ["twisted"]
 zookeeper = ["kazoo"]
@@ -1327,16 +1327,6 @@ files = [
 [package.extras]
 cli = ["click (>=5.0)"]
 
-[[package]]
-name = "pytz"
-version = "2025.2"
-description = "World timezone definitions, modern and historical"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
-    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
-]
 
 [[package]]
 name = "qrcode"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ tweepy                = "4.15.0"
 openai                = "1.82.0"
 httpx                 = "0.28.1"
 httpcore              = "1.0.9"
-pytz                  = "2025.2"
+# pytz replaced by Python's zoneinfo
 toml                  = "0.10.2"
 
 # ───── Development & testing ───────────────────────────────────────────

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,8 +5,7 @@ from urllib.parse import urlparse, parse_qs
 from app import create_app, db
 from app.models import User
 from flask import url_for
-from datetime import datetime
-from pytz import utc
+from datetime import datetime, timezone
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import text
 
@@ -52,7 +51,7 @@ def user_normal(app):
     )
     u.set_password("secret")
     # Fix created_at to avoid timezone errors
-    u.created_at = datetime.now(utc)
+    u.created_at = datetime.now(timezone.utc)
     db.session.add(u)
     db.session.commit()
     return u
@@ -67,7 +66,7 @@ def user_unverified(app):
         email_verified=False,
     )
     u.set_password("secret")
-    u.created_at = datetime.now(utc)
+    u.created_at = datetime.now(timezone.utc)
     db.session.add(u)
     db.session.commit()
     return u

--- a/tests/test_auth_extra.py
+++ b/tests/test_auth_extra.py
@@ -4,8 +4,7 @@ import pytest
 from flask import url_for
 from app import create_app, db
 from app.models import User
-from datetime import datetime
-from pytz import utc
+from datetime import datetime, timezone
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import text
 
@@ -44,7 +43,7 @@ def client(app):
 def normal_user(app):
     u = User(username="norm", email="norm@e.com", email_verified=True, license_agreed=True)
     u.set_password("pw")
-    u.created_at = datetime.now(utc)
+    u.created_at = datetime.now(timezone.utc)
     db.session.add(u)
     db.session.commit()
     return u
@@ -53,7 +52,7 @@ def normal_user(app):
 def admin_user(app):
     u = User(username="admin", email="admin@e.com", email_verified=True, license_agreed=True, is_admin=True)
     u.set_password("pw")
-    u.created_at = datetime.now(utc)
+    u.created_at = datetime.now(timezone.utc)
     db.session.add(u)
     db.session.commit()
     return u

--- a/tests/test_liaison_email.py
+++ b/tests/test_liaison_email.py
@@ -1,6 +1,5 @@
 import pytest
-from datetime import datetime, timedelta
-from pytz import utc
+from datetime import datetime, timedelta, timezone
 
 from app import create_app, db
 from app.models import Game, Quest, User, QuestSubmission
@@ -41,8 +40,8 @@ def test_liaison_email_lists_all_submissions(app, monkeypatch):
 
         game = Game(
             title="Test Game",
-            start_date=datetime.now(utc) - timedelta(days=1),
-            end_date=datetime.now(utc) + timedelta(days=1),
+            start_date=datetime.now(timezone.utc) - timedelta(days=1),
+            end_date=datetime.now(timezone.utc) + timedelta(days=1),
             admin_id=admin.id,
             social_media_liaison_email="liaison@example.com",
         )
@@ -61,8 +60,8 @@ def test_liaison_email_lists_all_submissions(app, monkeypatch):
         db.session.add_all([sharer, nonsharer])
         db.session.commit()
 
-        sub1 = QuestSubmission(quest_id=quest.id, user_id=sharer.id, timestamp=datetime.now(utc))
-        sub2 = QuestSubmission(quest_id=quest.id, user_id=nonsharer.id, timestamp=datetime.now(utc))
+        sub1 = QuestSubmission(quest_id=quest.id, user_id=sharer.id, timestamp=datetime.now(timezone.utc))
+        sub2 = QuestSubmission(quest_id=quest.id, user_id=nonsharer.id, timestamp=datetime.now(timezone.utc))
         db.session.add_all([sub1, sub2])
         db.session.commit()
 

--- a/tests/test_manage_quests_logic.py
+++ b/tests/test_manage_quests_logic.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime, timedelta
-from pytz import utc
+from datetime import timezone
 
 from app import create_app, db
 from app.models import Game, Quest, User
@@ -32,7 +32,7 @@ def client(app):
 def admin_user(app):
     user = User(username="admin", email="admin@example.com", is_admin=True, license_agreed=True, email_verified=True)
     user.set_password("pw")
-    user.created_at = datetime.now(utc)
+    user.created_at = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -55,8 +55,8 @@ def login_as(client, user):
 def create_game(title, admin_id):
     game = Game(
         title=title,
-        start_date=datetime.now(utc) - timedelta(days=1),
-        end_date=datetime.now(utc) + timedelta(days=1),
+        start_date=datetime.now(timezone.utc) - timedelta(days=1),
+        end_date=datetime.now(timezone.utc) + timedelta(days=1),
         admin_id=admin_id,
     )
     return game

--- a/tests/test_quest_display.py
+++ b/tests/test_quest_display.py
@@ -1,6 +1,5 @@
 import pytest
-from datetime import datetime, timedelta
-from pytz import utc
+from datetime import datetime, timedelta, timezone
 
 from app import create_app, db
 from app.models import Game, User, Quest, QuestSubmission, Badge
@@ -33,8 +32,8 @@ def test_prepare_quests_hides_unbadged_empty(app):
 
         game = Game(
             title="Test Game",
-            start_date=datetime.now(utc) - timedelta(days=1),
-            end_date=datetime.now(utc) + timedelta(days=1),
+            start_date=datetime.now(timezone.utc) - timedelta(days=1),
+            end_date=datetime.now(timezone.utc) + timedelta(days=1),
             admin_id=admin.id,
         )
         db.session.add(game)
@@ -54,7 +53,7 @@ def test_prepare_quests_hides_unbadged_empty(app):
         db.session.add(sub)
         db.session.commit()
 
-        quests, _ = _prepare_quests(game, admin.id, [], datetime.now(utc))
+        quests, _ = _prepare_quests(game, admin.id, [], datetime.now(timezone.utc))
         ids = [q.id for q in quests]
         assert q1.id not in ids
         assert q2.id in ids
@@ -69,8 +68,8 @@ def test_prepare_quests_hides_badgeless_image(app):
 
         game = Game(
             title="Test Game2",
-            start_date=datetime.now(utc) - timedelta(days=1),
-            end_date=datetime.now(utc) + timedelta(days=1),
+            start_date=datetime.now(timezone.utc) - timedelta(days=1),
+            end_date=datetime.now(timezone.utc) + timedelta(days=1),
             admin_id=admin.id,
         )
         db.session.add(game)
@@ -92,7 +91,7 @@ def test_prepare_quests_hides_badgeless_image(app):
         db.session.add(sub)
         db.session.commit()
 
-        quests, _ = _prepare_quests(game, admin.id, [], datetime.now(utc))
+        quests, _ = _prepare_quests(game, admin.id, [], datetime.now(timezone.utc))
         ids = [q.id for q in quests]
         assert q1.id not in ids
         assert q2.id in ids
@@ -108,8 +107,8 @@ def test_prepare_user_data_hides_badgeless_image(app):
 
         game = Game(
             title="Test Game3",
-            start_date=datetime.now(utc) - timedelta(days=1),
-            end_date=datetime.now(utc) + timedelta(days=1),
+            start_date=datetime.now(timezone.utc) - timedelta(days=1),
+            end_date=datetime.now(timezone.utc) + timedelta(days=1),
             admin_id=admin.id,
         )
         db.session.add(game)

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -4,8 +4,7 @@ from urllib.parse import urlparse, parse_qs
 from app import create_app, db
 from app.models import User
 from flask import url_for
-from datetime import datetime
-from pytz import utc
+from datetime import datetime, timezone
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import text
 
@@ -49,7 +48,7 @@ def user_existing(app):
         email_verified=True,
     )
     u.set_password("secret")
-    u.created_at = datetime.now(utc)
+    u.created_at = datetime.now(timezone.utc)
     db.session.add(u)
     db.session.commit()
     return u

--- a/tests/test_registration_extra.py
+++ b/tests/test_registration_extra.py
@@ -2,8 +2,7 @@ import pytest
 from flask import url_for
 from app import create_app, db
 from app.models import User
-from datetime import datetime
-from pytz import utc
+from datetime import datetime, timezone
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import text
 


### PR DESCRIPTION
## Summary
- drop pytz dependency in favour of Python's `zoneinfo`
- update application modules to use `timezone.utc`
- adjust SQLAlchemy defaults accordingly
- update tests to use the standard library timezone

## Testing
- `pip install flask flask_sqlalchemy flask_login flask_wtf flask-assets werkzeug==3.1.3 sqlalchemy psycopg2-binary wtforms email-validator cryptography pyjwt bleach gunicorn apscheduler qrcode[pil] tweepy openai httpx httpcore toml pytest python-dotenv rsa`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dfe42710832ba6387aa456219e14