### PR TITLE
Implement typed delete with undo for games

### DIFF
--- a/app/static/js/delete_game_modal.js
+++ b/app/static/js/delete_game_modal.js
@@ -1,0 +1,53 @@
+let deleteInterval;
+
+function openDeleteGameModal(gameId) {
+  const modal = document.getElementById('deleteGameModal');
+  const form  = document.getElementById('deleteGameForm');
+  const input = document.getElementById('deleteGameConfirmInput');
+  const countdown = document.getElementById('deleteGameCountdown');
+  const timerSpan = document.getElementById('deleteGameTimer');
+  const confirmBtn = document.getElementById('deleteGameConfirmBtn');
+
+  modal.dataset.gameId = gameId;
+  form.action = `/games/delete_game/${gameId}`;
+  input.value = '';
+  confirmBtn.disabled = true;
+  countdown.hidden = true;
+  timerSpan.textContent = '5';
+  openModal('deleteGameModal');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('deleteGameConfirmInput');
+  const confirmBtn = document.getElementById('deleteGameConfirmBtn');
+  const countdown = document.getElementById('deleteGameCountdown');
+  const timerSpan = document.getElementById('deleteGameTimer');
+  const undoBtn = document.getElementById('deleteGameUndo');
+  const form = document.getElementById('deleteGameForm');
+
+  input.addEventListener('input', () => {
+    confirmBtn.disabled = input.value.trim().toLowerCase() !== 'delete';
+  });
+
+  confirmBtn.addEventListener('click', () => {
+    let seconds = 5;
+    countdown.hidden = false;
+    timerSpan.textContent = seconds.toString();
+    deleteInterval = setInterval(() => {
+      seconds -= 1;
+      timerSpan.textContent = seconds.toString();
+      if (seconds <= 0) {
+        clearInterval(deleteInterval);
+        form.submit();
+      }
+    }, 1000);
+  });
+
+  undoBtn.addEventListener('click', () => {
+    clearInterval(deleteInterval);
+    countdown.hidden = true;
+    timerSpan.textContent = '5';
+    input.value = '';
+    confirmBtn.disabled = true;
+  });
+});

--- a/app/static/scss/components/_delete_game_modal.scss
+++ b/app/static/scss/components/_delete_game_modal.scss
@@ -1,0 +1,3 @@
+#deleteGameCountdown {
+  font-weight: bold;
+}

--- a/app/static/scss/main.scss
+++ b/app/static/scss/main.scss
@@ -29,6 +29,7 @@
 @import 'components/badge_modal';
 @import 'components/loading_modal';
 @import 'components/all_submissions_modal';
+@import 'components/delete_game_modal';
 @import 'components/quest_detail_modal';
 @import 'components/leaderboard_modal';
 @import 'components/sponsors-modal';

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -44,10 +44,7 @@
                             <td>{{ game.description }}</td>
                             <td class="text-end">
                                 <a href="{{ url_for('games.update_game', game_id=game.id) }}" class="btn btn-sm btn-info me-2">Edit</a>
-                                <form action="{{ url_for('games.delete_game', game_id=game.id) }}" method="post" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this game?');">
-                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                                    <button type="submit" class="btn btn-sm btn-danger me-2">Delete</button>
-                                </form>
+                                <button type="button" class="btn btn-sm btn-danger me-2" onclick="openDeleteGameModal({{ game.id }})">Delete</button>
                                 <a href="{{ url_for('quests.manage_game_quests', game_id=game.id) }}" class="btn btn-sm btn-primary me-2">Quests</a>
                                 <a href="{{ url_for('badges.manage_badges', game_id=game.id) }}" class="btn btn-sm btn-primary me-2">Badges</a>
                                 <a href="{{ url_for('games.generate_qr_for_game', game_id=game.id) }}" class="btn btn-sm btn-success" title="Generate QR Code">
@@ -71,6 +68,7 @@
 {% include 'modals/game_info_modal.html' %}
 {% include 'modals/user_profile_modal.html' %}
 {% include 'modals/leaderboard_modal.html' %}
+{% include 'modals/delete_game_modal.html' %}
 
 <script src="{{ url_for('static', filename='js/modal_common.js') }}"></script>
 <script src="{{ url_for('static', filename='js/all_submissions_modal.js') }}"></script>
@@ -78,5 +76,6 @@
 <script src="{{ url_for('static', filename='js/user_profile_modal.js') }}"></script>
 <script src="{{ url_for('static', filename='js/leaderboard_modal.js') }}"></script>
 <script src="{{ url_for('static', filename='js/index_management.js') }}"></script>
+<script src="{{ url_for('static', filename='js/delete_game_modal.js') }}"></script>
 
 {% endblock %}

--- a/app/templates/modals/delete_game_modal.html
+++ b/app/templates/modals/delete_game_modal.html
@@ -1,0 +1,20 @@
+<div id="deleteGameModal" class="modal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h5 class="modal-title">Delete Game</h5>
+      <button type="button" class="btn-close" aria-label="Close" onclick="closeModal('deleteGameModal')"></button>
+    </div>
+    <div class="modal-body">
+      <p>Type <strong>delete</strong> to confirm.</p>
+      <input type="text" id="deleteGameConfirmInput" class="form-control mb-3" placeholder="delete">
+      <div id="deleteGameCountdown" class="mb-3" hidden>
+        Deleting in <span id="deleteGameTimer">5</span>...
+        <button id="deleteGameUndo" class="btn btn-sm btn-secondary ms-2">Undo</button>
+      </div>
+      <button id="deleteGameConfirmBtn" class="btn btn-danger" disabled>Delete</button>
+    </div>
+  </div>
+  <form id="deleteGameForm" method="post" style="display:none;">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- add modal & script for 5‑second undo on game deletion
- wire delete button in admin dashboard to new modal
- import modal styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845e16ea9c0832b8a75d18ec66c0ecf