### PR TITLE
Fix badge load error when switching games

### DIFF
--- a/app/static/js/badge_modal.js
+++ b/app/static/js/badge_modal.js
@@ -9,7 +9,8 @@ window.allBadges = window.allBadges || [];
 async function fetchAllBadges() {
   const gameHolder = document.getElementById("game_IdHolder");
   const selectedGameId = gameHolder ? gameHolder.getAttribute("data-game-id") : null;
-  const url = new URL('/badges', window.location.origin);
+  // Avoid a redirect by hitting the route with the trailing slash
+  const url = new URL('/badges/', window.location.origin);
   if (selectedGameId && !isNaN(parseInt(selectedGameId, 10)) && selectedGameId !== "0") {
     url.searchParams.set('game_id', selectedGameId);
   }


### PR DESCRIPTION
## Summary
- stop redirect when requesting badges by using trailing slash

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e8d22d80832b877b27bc2c343a52