### PR TITLE
Fix quest detail JS included twice

### DIFF
--- a/app/templates/modals/quest_detail_modal.html
+++ b/app/templates/modals/quest_detail_modal.html
@@ -77,6 +77,4 @@
     </div>
 </div>
 
-<script src="{{ url_for('static', filename='js/quest_detail_modal.js') }}"></script>
-
     <!-- styles moved to SCSS -->


### PR DESCRIPTION
## Summary
- remove duplicate script include from quest detail modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845ecec6344832bba943e814c7864dc