### PR TITLE
Fix ActivityPub signature header formatting

### DIFF
--- a/app/activitypub_utils.py
+++ b/app/activitypub_utils.py
@@ -100,12 +100,12 @@ def sign_activitypub_request(actor, method, url, body):
     signature = rsa.sign(signing_string, priv, 'SHA-256')
     sig_hex = signature.hex()
     key_id = f"{actor.activitypub_id}#main-key"
-    signature_header = (
-        f'keyId="{key_id}",'  
-        'algorithm="rsa-sha256",'
-        'headers="(request-target) host date",'
+    signature_header = ", ".join([
+        f'keyId="{key_id}"',
+        'algorithm="rsa-sha256"',
+        'headers="(request-target) host date"',
         f'signature="{sig_hex}"'
-    )
+    ])
     return {
         'Date': date_header,
         'Host': parsed.netloc,


### PR DESCRIPTION
## Summary
- ensure ActivityPub signature header is a proper string
- test that the header string is returned

## Testing
- `PYTHONPATH=. pytest tests/test_activitypub_delivery.py::test_sign_request_returns_string -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f043a638832ba1e5a1320fc89d6d