### PR TITLE
Reduce quill init duplication

### DIFF
--- a/app/static/js/add_quest.js
+++ b/app/static/js/add_quest.js
@@ -1,36 +1,5 @@
-var quillDescription = new Quill('#description-editor', {
-    theme: 'snow',
-    modules: {
-        toolbar: [
-            [{ 'font': [] }, { 'size': [] }],
-            ['bold', 'italic', 'underline', 'strike'],
-            [{ 'color': [] }, { 'background': [] }],
-            [{ 'script': 'sub'}, { 'script': 'super' }],
-            [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }, { 'header': 4 }, { 'header': 5 }, { 'header': 6 }, 'blockquote', 'code-block'],
-            [{ 'list': 'ordered'}, { 'list': 'bullet' }, { 'indent': '-1'}, { 'indent': '+1' }],
-            [{ 'direction': 'rtl' }, { 'align': [] }],
-            ['link', 'image', 'video', 'formula'],
-            ['clean']
-        ]
-    }
-});
-
-var quillTips = new Quill('#tips-editor', {
-    theme: 'snow',
-    modules: {
-        toolbar: [
-            [{ 'font': [] }, { 'size': [] }],
-            ['bold', 'italic', 'underline', 'strike'],
-            [{ 'color': [] }, { 'background': [] }],
-            [{ 'script': 'sub'}, { 'script': 'super' }],
-            [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }, { 'header': 4 }, { 'header': 5 }, { 'header': 6 }, 'blockquote', 'code-block'],
-            [{ 'list': 'ordered'}, { 'list': 'bullet' }, { 'indent': '-1'}, { 'indent': '+1' }],
-            [{ 'direction': 'rtl' }, { 'align': [] }],
-            ['link', 'image', 'video', 'formula'],
-            ['clean']
-        ]
-    }
-});
+var quillDescription = initQuill('#description-editor');
+var quillTips        = initQuill('#tips-editor');
 
 document.getElementById('quest-form').onsubmit = function(e) {
     // Get the Quill editor contents

--- a/app/static/js/create_game.js
+++ b/app/static/js/create_game.js
@@ -1,29 +1,7 @@
     document.addEventListener('DOMContentLoaded', function() {
-        const quillOptions = {
-            theme: 'snow',
-            modules: {
-                toolbar: [
-                    [{ 'font': [] }, { 'size': [] }],
-                    ['bold', 'italic', 'underline', 'strike'],
-                    [{ 'color': [] }, { 'background': [] }],
-                    [{ 'script': 'sub'}, { 'script': 'super' }],
-                    [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }, { 'header': 4 }, { 'header': 5 }, { 'header': 6 }, 'blockquote', 'code-block'],
-                    [{ 'list': 'ordered'}, { 'list': 'bullet' }, { 'indent': '-1'}, { 'indent': '+1' }],
-                    [{ 'direction': 'rtl' }, { 'align': [] }],
-                    ['link', 'image', 'video', 'formula'],
-                    ['clean']
-                ]
-            }
-        };
-
         const editors = ['description', 'description2', 'details', 'awards', 'beyond'];
 
         editors.forEach(editorId => {
-            const quillEditor = new Quill(`#${editorId}`, quillOptions);
-            const hiddenInput = document.getElementById(`${editorId}-textarea`);
-
-            quillEditor.on('text-change', function() {
-                hiddenInput.value = quillEditor.root.innerHTML;
-            });
+            initQuill(`#${editorId}`, `#${editorId}-textarea`);
         });
     });

--- a/app/static/js/edit_sponsors.js
+++ b/app/static/js/edit_sponsors.js
@@ -1,30 +1,3 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const quillOptions = {
-        theme: 'snow',
-        modules: {
-            toolbar: [
-                [{ 'font': [] }, { 'size': [] }],
-                ['bold', 'italic', 'underline', 'strike'],
-                [{ 'color': [] }, { 'background': [] }],
-                [{ 'script': 'sub'}, { 'script': 'super' }],
-                [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }, { 'header': 4 }, { 'header': 5 }, { 'header': 6 }, 'blockquote', 'code-block'],
-                [{ 'list': 'ordered'}, { 'list': 'bullet' }, { 'indent': '-1'}, { 'indent': '+1' }],
-                [{ 'direction': 'rtl' }, { 'align': [] }],
-                ['link', 'image', 'video', 'formula'],
-                ['clean']
-            ]
-        }
-    };
-
-    const descriptionEditor = new Quill('#description', quillOptions);
-    const descriptionTextarea = document.getElementById('description-textarea');
-
-    // Set the initial content of the Quill editor
-    if (descriptionTextarea.value) {
-        descriptionEditor.root.innerHTML = descriptionTextarea.value;
-    }
-
-    descriptionEditor.on('text-change', function() {
-        descriptionTextarea.value = descriptionEditor.root.innerHTML;
-    });
+    initQuill('#description', '#description-textarea');
 });

--- a/app/static/js/index_management.js
+++ b/app/static/js/index_management.js
@@ -109,15 +109,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const quillEditorContainer = document.getElementById('quill-editor');
   if (quillEditorContainer) {
-    const quill = new Quill('#quill-editor', {
-      theme: 'snow',
+    const quill = initQuill('#quill-editor', '#message-input', {
       placeholder: 'Write a message...',
       modules: { toolbar: [[{ header: [1, 2, false] }], ['bold', 'italic', 'underline'], ['link'], [{ list: 'ordered' }, { list: 'bullet' }], ['clean']] }
     });
-    document.querySelector('form').onsubmit = () => {
-      document.querySelector('#message-input').value = quill.root.innerHTML;
-      return true;
-    };
+    document.querySelector('form').onsubmit = () => true;
   }
 
   document.querySelectorAll('.activity-message').forEach(el => {

--- a/app/static/js/manage_quests.js
+++ b/app/static/js/manage_quests.js
@@ -215,22 +215,7 @@
             cell.innerHTML = '';
             cell.appendChild(editor);
             
-            const quill = new Quill(editor, {
-                theme: 'snow',
-                modules: {
-                    toolbar: [
-                        [{ 'font': [] }, { 'size': [] }],
-                        ['bold', 'italic', 'underline', 'strike'],
-                        [{ 'color': [] }, { 'background': [] }],
-                        [{ 'script': 'sub'}, { 'script': 'super' }],
-                        [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }, { 'header': 4 }, { 'header': 5 }, { 'header': 6 }, 'blockquote', 'code-block'],
-                        [{ 'list': 'ordered'}, { 'list': 'bullet' }, { 'indent': '-1'}, { 'indent': '+1' }],
-                        [{ 'direction': 'rtl' }, { 'align': [] }],
-                        ['link', 'image', 'video', 'formula'],
-                        ['clean']
-                    ]
-                }
-            });
+            const quill = initQuill(editor);
 
             quill.root.innerHTML = currentValue;
             cell.__quill = quill;
@@ -453,42 +438,12 @@
             const tipsEditorContainer = card.querySelector('.quill-editor-container[data-name="tips"]');
 
             if (descriptionEditorContainer && !descriptionEditorContainer.__quill) {
-                const quillDescription = new Quill(descriptionEditorContainer, {
-                    theme: 'snow',
-                    modules: {
-                        toolbar: [
-                            [{ 'font': [] }, { 'size': [] }],
-                            ['bold', 'italic', 'underline', 'strike'],
-                            [{ 'color': [] }, { 'background': [] }],
-                            [{ 'script': 'sub'}, { 'script': 'super' }],
-                            [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }, { 'header': 4 }, { 'header': 5 }, { 'header': 6 }, 'blockquote', 'code-block'],
-                            [{ 'list': 'ordered'}, { 'list': 'bullet' }, { 'indent': '-1'}, { 'indent': '+1' }],
-                            [{ 'direction': 'rtl' }, { 'align': [] }],
-                            ['link', 'image', 'video', 'formula'],
-                            ['clean']
-                        ]
-                    }
-                });
+                const quillDescription = initQuill(descriptionEditorContainer);
                 descriptionEditorContainer.__quill = quillDescription;
             }
 
             if (tipsEditorContainer && !tipsEditorContainer.__quill) {
-                const quillTips = new Quill(tipsEditorContainer, {
-                    theme: 'snow',
-                    modules: {
-                        toolbar: [
-                            [{ 'font': [] }, { 'size': [] }],
-                            ['bold', 'italic', 'underline', 'strike'],
-                            [{ 'color': [] }, { 'background': [] }],
-                            [{ 'script': 'sub'}, { 'script': 'super' }],
-                            [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }, { 'header': 4 }, { 'header': 5 }, { 'header': 6 }, 'blockquote', 'code-block'],
-                            [{ 'list': 'ordered'}, { 'list': 'bullet' }, { 'indent': '-1'}, { 'indent': '+1' }],
-                            [{ 'direction': 'rtl' }, { 'align': [] }],
-                            ['link', 'image', 'video', 'formula'],
-                            ['clean']
-                        ]
-                    }
-                });
+                const quillTips = initQuill(tipsEditorContainer);
                 tipsEditorContainer.__quill = quillTips;
             }
         }

--- a/app/static/js/manage_sponsors.js
+++ b/app/static/js/manage_sponsors.js
@@ -1,30 +1,8 @@
     document.addEventListener('DOMContentLoaded', function() {
-        const quillOptions = {
-            theme: 'snow',
-            modules: {
-                toolbar: [
-                    [{ 'font': [] }, { 'size': [] }],
-                    ['bold', 'italic', 'underline', 'strike'],
-                    [{ 'color': [] }, { 'background': [] }],
-                    [{ 'script': 'sub'}, { 'script': 'super' }],
-                    [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }, { 'header': 4 }, { 'header': 5 }, { 'header': 6 }, 'blockquote', 'code-block'],
-                    [{ 'list': 'ordered'}, { 'list': 'bullet' }, { 'indent': '-1'}, { 'indent': '+1' }],
-                    [{ 'direction': 'rtl' }, { 'align': [] }],
-                    ['link', 'image', 'video', 'formula'],
-                    ['clean']
-                ]
-            }
-        };
-
-        const descriptionEditor = new Quill('#description', quillOptions);
+        const descriptionEditor = initQuill('#description', '#description-textarea');
         const descriptionTextarea = document.getElementById('description-textarea');
 
-        if (descriptionTextarea) { // Ensure the element exists before interacting with it
-            descriptionEditor.on('text-change', function() {
-                descriptionTextarea.value = descriptionEditor.root.innerHTML;
-            });
-
-            // Set initial value if there's any data
+        if (descriptionEditor && descriptionTextarea) {
             descriptionEditor.root.innerHTML = descriptionTextarea.value;
         }
     });

--- a/app/static/js/quill_common.js
+++ b/app/static/js/quill_common.js
@@ -1,0 +1,36 @@
+window.QUILL_OPTIONS = {
+  theme: 'snow',
+  modules: {
+    toolbar: [
+      [{ font: [] }, { size: [] }],
+      ['bold', 'italic', 'underline', 'strike'],
+      [{ color: [] }, { background: [] }],
+      [{ script: 'sub' }, { script: 'super' }],
+      [{ header: 1 }, { header: 2 }, { header: 3 }, { header: 4 }, { header: 5 }, { header: 6 }, 'blockquote', 'code-block'],
+      [{ list: 'ordered' }, { list: 'bullet' }, { indent: '-1' }, { indent: '+1' }],
+      [{ direction: 'rtl' }, { align: [] }],
+      ['link', 'image', 'video', 'formula'],
+      ['clean']
+    ]
+  }
+};
+
+window.initQuill = function(selector, hidden, options = {}) {
+  const el = typeof selector === 'string' ? document.querySelector(selector) : selector;
+  if (!el) {
+    console.error('initQuill: element not found for', selector);
+    return null;
+  }
+  const opts = Object.assign({}, window.QUILL_OPTIONS, options);
+  const q = new Quill(el, opts);
+  if (hidden) {
+    const input = typeof hidden === 'string' ? document.querySelector(hidden) : hidden;
+    if (input) {
+      if (input.value) q.root.innerHTML = input.value;
+      q.on('text-change', () => {
+        input.value = q.root.innerHTML;
+      });
+    }
+  }
+  return q;
+};

--- a/app/static/js/shout_board_modal.js
+++ b/app/static/js/shout_board_modal.js
@@ -5,13 +5,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const modalId   = 'shoutBoardModal';
   const formEl    = document.getElementById('shoutBoardForm');
   const submitBtn = document.getElementById('shoutSubmitBtn');
-  let   quill     = null;
+  let quill = null;
 
   /* -------------------- initialise Quill once -------------------- */
   if (window.Quill) {
-    quill = new Quill('#shoutQuillEditor', {
-      theme       : 'snow',
-      placeholder : 'Write an announcement…'
+    quill = initQuill('#shoutQuillEditor', '#shoutMessageInput', {
+      placeholder: 'Write an announcement…'
     });
   } else {
     console.error('Quill library not found  shoutboard editor will not work.');

--- a/app/static/js/update_game.js
+++ b/app/static/js/update_game.js
@@ -1,34 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const quillOptions = {
-        theme: 'snow',
-        modules: {
-            toolbar: [
-                [{ 'font': [] }, { 'size': [] }],
-                ['bold', 'italic', 'underline', 'strike'],
-                [{ 'color': [] }, { 'background': [] }],
-                [{ 'script': 'sub'}, { 'script': 'super' }],
-                [{ 'header': 1 }, { 'header': 2 }, { 'header': 3 }, { 'header': 4 }, { 'header': 5 }, { 'header': 6 }, 'blockquote', 'code-block'],
-                [{ 'list': 'ordered'}, { 'list': 'bullet' }, { 'indent': '-1'}, { 'indent': '+1' }],
-                [{ 'direction': 'rtl' }, { 'align': [] }],
-                ['link', 'image', 'video', 'formula'],
-                ['clean']
-            ]
-        }
-    };
-
     const editors = ['description', 'description2', 'details', 'awards', 'beyond'];
 
     editors.forEach(editorId => {
-        const quillEditor = new Quill(`#${editorId}`, quillOptions);
-        const hiddenInput = document.getElementById(`${editorId}-textarea`);
-
-        // Set the Quill editor's content to the value of the corresponding textarea
-        if (hiddenInput.value) {
-            quillEditor.root.innerHTML = hiddenInput.value;
-        }
-
-        quillEditor.on('text-change', function() {
-            hiddenInput.value = quillEditor.root.innerHTML;
-        });
+        initQuill(`#${editorId}`, `#${editorId}-textarea`);
     });
 });

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -64,6 +64,7 @@
   <script src="{{ url_for('static', filename='js/3rd/highlight.min.js') }}"></script>
   <script src="{{ url_for('static', filename='js/3rd/katex.min.js') }}"></script>
   <script src="{{ url_for('static', filename='js/3rd/quill.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/quill_common.js') }}"></script>
 </head>
 
 <body data-user-id="{{ current_user.id if current_user.is_authenticated else 'none' }}">


### PR DESCRIPTION
## Summary
- centralize quill configuration in new `quill_common.js`
- load common script in the layout template
- use `initQuill` helper across JS files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846407495d0832b8c81e068fed0b330