### PR TITLE
Fix JS fetch endpoints

### DIFF
--- a/app/static/js/badge_modal.js
+++ b/app/static/js/badge_modal.js
@@ -9,8 +9,8 @@ window.allBadges = window.allBadges || [];
 async function fetchAllBadges() {
   const gameHolder = document.getElementById("game_IdHolder");
   const selectedGameId = gameHolder ? gameHolder.getAttribute("data-game-id") : null;
-  // Avoid a redirect by hitting the route with the trailing slash
-  const url = new URL('/badges/', window.location.origin);
+  // Hit the badge endpoint directly without a trailing slash
+  const url = new URL('/badges', window.location.origin);
   if (selectedGameId && !isNaN(parseInt(selectedGameId, 10)) && selectedGameId !== "0") {
     url.searchParams.set('game_id', selectedGameId);
   }

--- a/app/static/js/index_management.js
+++ b/app/static/js/index_management.js
@@ -50,7 +50,7 @@ function updateGameName() {
 
   const gameId = gameHolder.getAttribute("data-game-id");
 
-  fetch(`/games/get_game/${gameId}`)
+  fetch(`/games/get_game/${gameId}`, { credentials: 'same-origin' })
     .then(response => {
       if (!response.ok) {
         console.error(


### PR DESCRIPTION
## Summary
- fetch badges from `/badges` instead of `/badges/`
- send cookies when retrieving game name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6846428272cc832b874f897dfed71275