### PR TITLE
Refactor common JS tasks

### DIFF
--- a/app/static/js/forgot_password_modal.js
+++ b/app/static/js/forgot_password_modal.js
@@ -19,25 +19,19 @@ document.addEventListener('DOMContentLoaded', () => {
     emailErr.style.display   = 'none';
     successDiv.style.display = 'none';
 
-    fetch(form.action, {
-      method: 'POST',
-      headers: { 'X-Requested-With': 'XMLHttpRequest' },
-      body: new FormData(form),
-      credentials: 'same-origin'
-    })
-    .then(r => r.json().then(json => ({ status: r.status, json })))
-    .then(({ json }) => {
-      if (json.success) {
-        successDiv.textContent   = json.message;
-        successDiv.style.display = 'block';
-        btn.disabled             = true;
-      } else {
-        emailErr.textContent   = json.error || 'An error occurred.';
-        emailErr.style.display = 'block';
-      }
-    })
-    .catch(_ => {
-      form.submit();
-    });
+    submitFormJson(form)
+      .then(({ json }) => {
+        if (json.success) {
+          successDiv.textContent   = json.message;
+          successDiv.style.display = 'block';
+          btn.disabled             = true;
+        } else {
+          emailErr.textContent   = json.error || 'An error occurred.';
+          emailErr.style.display = 'block';
+        }
+      })
+      .catch(() => {
+        form.submit();
+      });
   });
 });

--- a/app/static/js/game_info_modal.js
+++ b/app/static/js/game_info_modal.js
@@ -1,32 +1,6 @@
 function showGameInfoModal(gameId) {
-    // Adjust the URL based on your blueprint's URL prefix (assumed to be /games)
-    fetch('/games/game-info/' + gameId + '?modal=1')
-        .then(response => {
-            if (!response.ok) {
-                throw new Error("Failed to fetch game info");
-            }
-            return response.text();
-        })
-        .then(html => {
-            // Remove any existing modal with the same ID, if present.
-            let existingModal = document.getElementById('gameInfoModal');
-            if (existingModal) {
-                existingModal.parentNode.removeChild(existingModal);
-            }
-            // Create a temporary container and set its innerHTML to the fetched HTML
-            let tempDiv = document.createElement('div');
-            tempDiv.innerHTML = html;
-            // Assume that the first child is our complete modal element.
-            let modalElement = tempDiv.firstElementChild;
-            // Append the modal element to the document body
-            document.body.appendChild(modalElement);
-            // Display the modal by setting its display style to block (or using your preferred method)
-            document.getElementById('gameInfoModal').style.display = 'block';
-        })
-        .catch(error => {
-            console.error("Error loading game info:", error);
-            alert("Failed to load game info. Please try again later.");
-        });
+    const url = '/games/game-info/' + gameId + '?modal=1';
+    fetchAndShowModal(url, 'gameInfoModal');
 }
 
 // Expose the function globally so it can be called by inline onclick attributes.

--- a/app/static/js/login_modal.js
+++ b/app/static/js/login_modal.js
@@ -10,31 +10,24 @@ document.addEventListener('DOMContentLoaded', () => {
     pwdError.style.display = 'none';
     forgotDiv.innerHTML   = '';
 
-    const data = new FormData(form);
-    fetch(form.action, {
-      method: 'POST',
-      headers: { 'X-Requested-With': 'XMLHttpRequest' },
-      credentials: 'same-origin',
-      body: data
-    })
-    .then(r => r.json().then(payload => ({ status: r.status, payload })))
-    .then(({ payload }) => {
-      if (payload.success) {
-        window.location.href = payload.redirect;
-      } else {
-        pwdError.textContent = payload.error;
-        pwdError.style.display = 'block';
-        if (payload.show_forgot) {
-          const a = document.createElement('a');
-          a.href      = 'javascript:void(0)';
-          a.textContent = 'Forgot password?';
-          a.className = 'd-block mt-1';
-          a.onclick   = openForgotPasswordModal;
-          forgotDiv.appendChild(a);
+    submitFormJson(form)
+      .then(({ json }) => {
+        if (json.success) {
+          window.location.href = json.redirect;
+        } else {
+          pwdError.textContent = json.error;
+          pwdError.style.display = 'block';
+          if (json.show_forgot) {
+            const a = document.createElement('a');
+            a.href      = 'javascript:void(0)';
+            a.textContent = 'Forgot password?';
+            a.className = 'd-block mt-1';
+            a.onclick   = openForgotPasswordModal;
+            forgotDiv.appendChild(a);
+          }
         }
-      }
-    })
-    .catch(() => form.submit());
+      })
+      .catch(() => form.submit());
   });
 
   // email-exists check

--- a/app/static/js/modal_common.js
+++ b/app/static/js/modal_common.js
@@ -376,6 +376,18 @@ async function fetchAndShowModal(url, modalId) {
   }
 }
 
+// Submit a form via AJAX and return the JSON response
+async function submitFormJson(form) {
+  const res = await fetch(form.action, {
+    method: form.method || 'POST',
+    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    body: new FormData(form),
+    credentials: 'same-origin'
+  });
+  const json = await res.json();
+  return { status: res.status, json };
+}
+
 // wire up any [data-modal-url] triggers
 document.addEventListener('click', e => {
   const button = e.target.closest('[data-modal-url]');

--- a/app/static/js/reset_password_modal.js
+++ b/app/static/js/reset_password_modal.js
@@ -9,34 +9,26 @@ document.addEventListener('DOMContentLoaded', () => {
         errDiv.style.display     = 'none';
         successDiv.style.display = 'none';
 
-        fetch(form.action, {
-            method: 'POST',
-            headers: { 'X-Requested-With': 'XMLHttpRequest' },
-            body: new FormData(form),
-            credentials: 'same-origin'
-        })
-        .then(response =>
-            response.json().then(json => ({ status: response.status, json }))
-        )
-        .then(({ json }) => {
-            if (json.success) {
-                successDiv.textContent   = json.message;
-                successDiv.style.display = 'block';
-                btn.disabled             = true;
+        submitFormJson(form)
+            .then(({ json }) => {
+                if (json.success) {
+                    successDiv.textContent   = json.message;
+                    successDiv.style.display = 'block';
+                    btn.disabled             = true;
 
-                if (json.redirect) {
-                    setTimeout(() => {
-                        window.location.href = json.redirect;
-                    }, 1200);
+                    if (json.redirect) {
+                        setTimeout(() => {
+                            window.location.href = json.redirect;
+                        }, 1200);
+                    }
+                } else {
+                    errDiv.textContent   = json.error || 'Unable to reset password.';
+                    errDiv.style.display = 'block';
                 }
-            } else {
-                errDiv.textContent   = json.error || 'Unable to reset password.';
-                errDiv.style.display = 'block';
-            }
-        })
-        .catch(err => {
-            console.error('Reset-password AJAX error:', err);
-            form.submit();
-        });
+            })
+            .catch(err => {
+                console.error('Reset-password AJAX error:', err);
+                form.submit();
+            });
     });
 });


### PR DESCRIPTION
## Summary
- add `submitFormJson` helper in `modal_common.js`
- simplify login, reset, and forgot password modals to use the helper
- use `fetchAndShowModal` in `game_info_modal.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68464698660c832b8ec3c37f1a06d4fd