### PR TITLE
Fix badge fetching URL

### DIFF
--- a/app/static/js/badge_modal.js
+++ b/app/static/js/badge_modal.js
@@ -9,11 +9,12 @@ window.allBadges = window.allBadges || [];
 async function fetchAllBadges() {
   const gameHolder = document.getElementById("game_IdHolder");
   const selectedGameId = gameHolder ? gameHolder.getAttribute("data-game-id") : null;
-  // Hit the badge endpoint directly without a trailing slash
-  const url = new URL('/badges', window.location.origin);
-  if (selectedGameId && !isNaN(parseInt(selectedGameId, 10)) && selectedGameId !== "0") {
-    url.searchParams.set('game_id', selectedGameId);
-  }
+  // Build the badge endpoint explicitly to avoid accidental path prefixing
+  const query = (selectedGameId && !isNaN(parseInt(selectedGameId, 10)) &&
+                 selectedGameId !== "0")
+                 ? `?game_id=${selectedGameId}`
+                 : '';
+  const url = `/badges${query}`;
 
   const response = await fetch(url, { credentials: 'same-origin' });
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- fix badge URL construction in badge_modal.js

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684647939ae8832ba2f0509e7f639d25