### PR TITLE
Fix placeholder handling for submission images

### DIFF
--- a/app/static/js/quest_detail_modal.js
+++ b/app/static/js/quest_detail_modal.js
@@ -502,7 +502,7 @@ async function fetchSubmissions(questId) {
       .reverse()                     // newest first
       .map(sub => ({
         id:                  sub.id,
-        url:                 sub.image_url || sub.video_url,
+        url:                 sub.image_url || (sub.video_url ? null : '/static/images/default-placeholder.webp'),
         video_url:           sub.video_url,
         alt:                 'Submission Image',
         comment:             sub.comment,

--- a/app/static/js/submission_detail_modal.js
+++ b/app/static/js/submission_detail_modal.js
@@ -147,6 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
     el.imgOverlay.parentElement.onclick = el.profileLink.onclick;
 
     // submission image & comment
+    const placeholder = '/static/images/default-placeholder.webp';
     if (image.video_url) {
       el.img.hidden = true;
       el.video.hidden = false;
@@ -155,7 +156,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       el.video.hidden = true;
       el.img.hidden   = false;
-      el.img.src = image.url;
+      el.img.src = image.url || placeholder;
     }
     el.commentRead.textContent = image.comment || 'No comment provided.';
 


### PR DESCRIPTION
## Summary
- default to placeholder when a submission has no image
- use placeholder in detail modal if no image provided

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - no module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68464ab8bec4832ba0bc6b222cd99344