### PR TITLE
Add manifest route for PWA/TWA support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -923,6 +923,12 @@ def service_worker():
     return response
 
 
+@main_bp.route('/manifest.json')
+def manifest():
+    """Serve the PWA manifest from the application root."""
+    return current_app.send_static_file('manifest.json')
+
+
 @main_bp.route('/offline.html')
 def offline_page():
     """Return the offline fallback page."""

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -34,7 +34,7 @@
   <!-- Browser Compatibility Meta Tags -->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+  <link rel="manifest" href="{{ url_for('main.manifest') }}">
   <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <link rel="apple-touch-icon" href="{{ url_for('static', filename='icons/apple-touch-icon-180x180.png') }}">
 

--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -4,6 +4,7 @@ This application exposes basic Progressive Web App (PWA) features and can also b
 
 ## Offline Support
 - The file `app/static/offline.html` is served at `/offline.html` when the service worker is registered.
+- The PWA manifest at `app/static/manifest.json` is available from `/manifest.json`.
 - The service worker is registered from the root path: `/sw.js`.
 
 ## TWA Asset Links

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,26 @@
+import pytest
+
+from app import create_app
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+    ctx.pop()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_manifest_route(client):
+    resp = client.get('/manifest.json')
+    assert resp.status_code == 200
+    assert resp.mimetype == 'application/json'
+    data = resp.get_json()
+    assert data.get('name') == 'QuestByCycle'


### PR DESCRIPTION
## Summary
- expose `/manifest.json` route in `main_bp`
- reference new route in layout template
- document manifest route in PWA docs
- add tests for manifest route

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464ea2f298832bb0578dc9c020d530