### PR TITLE
Fix placeholder redeclaration

### DIFF
--- a/app/static/js/all_submissions_modal.js
+++ b/app/static/js/all_submissions_modal.js
@@ -1,5 +1,7 @@
 
-const PLACEHOLDER_IMAGE = document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
+var PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE ||
+    document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
+window.PLACEHOLDER_IMAGE = PLACEHOLDER_IMAGE;
 
 let submissionsPage = 0;
 let submissionsGameId = null;

--- a/app/static/js/badge_modal.js
+++ b/app/static/js/badge_modal.js
@@ -2,7 +2,9 @@
 
 // Cache all badges in a global variable once loaded
 window.allBadges = window.allBadges || [];
-const PLACEHOLDER_IMAGE = document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
+var PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE ||
+    document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
+window.PLACEHOLDER_IMAGE = PLACEHOLDER_IMAGE;
 
 /**
  * Validate that a given URL is a safe image source.

--- a/app/static/js/quest_detail_modal.js
+++ b/app/static/js/quest_detail_modal.js
@@ -8,9 +8,10 @@ function meta(name) {
 }
 
 /*  Current user ID and CSRF token pulled from <meta> tags.           */
-const CURRENT_USER_ID = Number(meta('current-user-id') || 0);
-const CSRF_TOKEN      = meta('csrf-token');
-const PLACEHOLDER_IMAGE = meta('placeholder-image');
+var CURRENT_USER_ID = Number(meta('current-user-id') || 0);
+var CSRF_TOKEN      = meta('csrf-token');
+var PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE || meta('placeholder-image');
+window.PLACEHOLDER_IMAGE = PLACEHOLDER_IMAGE;
 
 /* ------------------------------------------------------------------ */
 /*  OPEN QUEST DETAIL MODAL                                           */


### PR DESCRIPTION
## Summary
- avoid redeclaration errors by using a shared `PLACEHOLDER_IMAGE`
- expose the constant via `window` in multiple modals

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68465308d1b4832ba661e54ae5945a3c