### PR TITLE
Fix showAllSubmissionsModal reference error

### DIFF
--- a/app/static/js/all_submissions_modal.js
+++ b/app/static/js/all_submissions_modal.js
@@ -171,3 +171,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 });
+
+// Expose the modal function globally so other scripts can invoke it
+window.showAllSubmissionsModal = showAllSubmissionsModal;


### PR DESCRIPTION
## Summary
- expose `showAllSubmissionsModal` on `window`

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684653223dc0832b97e5c7e7c2a2e258