### PR TITLE
Limit image uploads to 8 MB

### DIFF
--- a/app/static/js/quest_detail_modal.js
+++ b/app/static/js/quest_detail_modal.js
@@ -410,6 +410,10 @@ async function submitQuestDetails(event, questId) {
       alert('Video must be 10 MB or smaller.');
       return;
     }
+    if (file && file.type.startsWith('image/') && file.size > 8 * 1024 * 1024) {
+      alert('Image must be 8 MB or smaller.');
+      return;
+    }
 
     const formData = new FormData(event.target);
     formData.append('user_id', CURRENT_USER_ID);

--- a/app/static/js/submission_detail_modal.js
+++ b/app/static/js/submission_detail_modal.js
@@ -70,6 +70,10 @@ document.addEventListener('DOMContentLoaded', () => {
         alert('Video must be 10 MB or smaller.');
         return;
       }
+      if (file.type.startsWith('image/') && file.size > 8 * 1024 * 1024) {
+        alert('Image must be 8 MB or smaller.');
+        return;
+      }
 
       const form = new FormData();
       if (file.type.startsWith('video/')) {

--- a/app/static/js/submit_photo.js
+++ b/app/static/js/submit_photo.js
@@ -18,6 +18,11 @@ document.addEventListener('DOMContentLoaded', function () {
             isSubmitting = false;
             return;
         }
+        if (file && file.type.startsWith('image/') && file.size > 8 * 1024 * 1024) {
+            displayFlashMessage('Image must be 8 MB or smaller.', 'error');
+            isSubmitting = false;
+            return;
+        }
 
         showFloatingModal();
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -63,7 +63,8 @@ ALLOWED_IMAGE_EXTENSIONS = {
     'png', 'jpg', 'jpeg', 'gif', 'webp', 'heif', 'heic'
 }
 ALLOWED_VIDEO_EXTENSIONS = {'mp4', 'webm', 'mov'}
-                                         
+
+MAX_IMAGE_BYTES = 8 * 1024 * 1024
 MAX_VIDEO_BYTES = 10 * 1024 * 1024
                                                        
 REQUEST_TIMEOUT = 5
@@ -114,6 +115,12 @@ def save_image_file(
 
     if not image_file or not getattr(image_file, "filename", None):
         raise ValueError("Invalid file object passed.")
+
+    image_file.seek(0, os.SEEK_END)
+    size = image_file.tell()
+    image_file.seek(0)
+    if size > MAX_IMAGE_BYTES:
+        raise ValueError("Image exceeds 8 MB limit")
 
     ext = image_file.filename.rsplit(".", 1)[-1].lower()
     if ext not in allowed_extensions:

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -81,6 +81,7 @@ The dashboard is your central hub for accessing games, quests, and community fea
 Quests can have different verification methods:
 - **Photo Verification**: Upload a photo as evidence of quest completion.
 - **Supported Image Formats**: PNG, JPG/JPEG, GIF, WebP, and HEIF/HEIC.
+- **Image Size Limit**: Images must be 8 MB or smaller.
 - **Comment Verification**: Provide a comment describing how you completed the quest.
 - **Photo and Comment Verification**: Both upload a photo and provide a comment.
 - **Video Verification**: Upload a short video as evidence, optionally with a comment. Videos are automatically compressed to stay under 10&nbsp;MB.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,3 +64,16 @@ def test_allowed_image_file_heif():
     """HEIF and HEIC images should be recognized as valid."""
     assert allowed_image_file("photo.heif")
     assert allowed_image_file("image.HEIC")
+
+
+def test_save_submission_image_too_large(app):
+    """Images larger than the limit should be rejected."""
+    from io import BytesIO
+    from werkzeug.datastructures import FileStorage
+    from app.utils import save_submission_image, MAX_IMAGE_BYTES
+
+    big_data = BytesIO(b"0" * (MAX_IMAGE_BYTES + 1))
+    file = FileStorage(stream=big_data, filename="big.jpg", content_type="image/jpeg")
+
+    with pytest.raises(ValueError):
+        save_submission_image(file)


### PR DESCRIPTION
## Summary
- enforce 8 MB image limit in backend `save_image_file`
- add frontend validation for images exceeding 8 MB
- document the image size limit for users
- test rejecting oversized image uploads

## Testing
- `PYTHONPATH=. poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465576ba04832bb9d675828dfd7b86