### PR TITLE
Add window controls overlay to PWA

### DIFF
--- a/app/static/js/layout.js
+++ b/app/static/js/layout.js
@@ -121,6 +121,18 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // --------------------------------------------------------------
+  // 5.5) Adjust body padding for window controls overlay
+  // --------------------------------------------------------------
+  if ('windowControlsOverlay' in navigator) {
+    function updateOverlayPadding() {
+      var rect = navigator.windowControlsOverlay.getTitlebarAreaRect();
+      document.body.style.paddingTop = rect.height + 'px';
+    }
+    navigator.windowControlsOverlay.addEventListener('geometrychange', updateOverlayPadding);
+    updateOverlayPadding();
+  }
+
+  // --------------------------------------------------------------
   // 6) Hoist modals to document.body to avoid clipping
   // --------------------------------------------------------------
   document.querySelectorAll('.modal').forEach(function(modal) {

--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -7,6 +7,7 @@
     "theme_color": "#D0E6B5",
     "background_color": "#f0f0f0",
     "display": "standalone",
+    "display_override": ["window-controls-overlay", "standalone"],
     "icons": [
       {
         "src": "/static/icons/icon_48x48.webp",

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -38,6 +38,12 @@
   <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <link rel="apple-touch-icon" href="{{ url_for('static', filename='icons/apple-touch-icon-180x180.png') }}">
 
+  <style>
+    @supports (top: env(titlebar-area-height)) {
+      body { padding-top: env(titlebar-area-height, 0); }
+    }
+  </style>
+
   <title>{% block title %}{% endblock %} - QuestByCycle</title>
 
   <!-- Load non-critical CSS asynchronously -->

--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -5,6 +5,7 @@ This application exposes basic Progressive Web App (PWA) features and can also b
 ## Offline Support
 - The file `app/static/offline.html` is served at `/offline.html` when the service worker is registered.
 - The PWA manifest at `app/static/manifest.json` is available from `/manifest.json`.
+- The manifest enables the `window-controls-overlay` display mode for desktop browsers using `display_override`.
 - The service worker is registered from the root path: `/sw.js`.
 
 ## TWA Asset Links

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
     "theme_color": "#D0E6B5",
     "background_color": "#f0f0f0",
     "display": "standalone",
+    "display_override": ["window-controls-overlay", "standalone"],
     "icons": [
         {
             "src": "/static/icons/icon_48x48.webp",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -24,3 +24,4 @@ def test_manifest_route(client):
     assert resp.mimetype == 'application/json'
     data = resp.get_json()
     assert data.get('name') == 'QuestByCycle'
+    assert 'window-controls-overlay' in data.get('display_override', [])


### PR DESCRIPTION
## Summary
- enable `window-controls-overlay` display mode in PWA manifest
- adjust layout for titlebar height on supported browsers
- document new display override setting
- test manifest includes window controls overlay option

## Testing
- `pytest tests/test_manifest.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68465c24c420832ba31fe168f3055496