### PR TITLE
Add launch handler to manifest

### DIFF
--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -7,6 +7,9 @@
     "theme_color": "#D0E6B5",
     "background_color": "#f0f0f0",
     "display": "standalone",
+    "launch_handler": {
+        "client_mode": "focus-existing"
+    },
     "icons": [
       {
         "src": "/static/icons/icon_48x48.webp",

--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -6,6 +6,7 @@ This application exposes basic Progressive Web App (PWA) features and can also b
 - The file `app/static/offline.html` is served at `/offline.html` when the service worker is registered.
 - The PWA manifest at `app/static/manifest.json` is available from `/manifest.json`.
 - The service worker is registered from the root path: `/sw.js`.
+- The manifest includes a `launch_handler` object specifying `"client_mode": "focus-existing"` so that repeated launches reuse the existing window.
 
 ## TWA Asset Links
 - The route `/.well-known/assetlinks.json` dynamically returns the digital asset links used for TWA verification.

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,9 @@
     "theme_color": "#D0E6B5",
     "background_color": "#f0f0f0",
     "display": "standalone",
+    "launch_handler": {
+        "client_mode": "focus-existing"
+    },
     "icons": [
         {
             "src": "/static/icons/icon_48x48.webp",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -24,3 +24,10 @@ def test_manifest_route(client):
     assert resp.mimetype == 'application/json'
     data = resp.get_json()
     assert data.get('name') == 'QuestByCycle'
+
+
+def test_launch_handler_is_object(client):
+    resp = client.get('/manifest.json')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data.get('launch_handler'), dict)


### PR DESCRIPTION
## Summary
- include a `launch_handler` object in both manifest files
- document the new manifest key in PWA docs
- test that `launch_handler` is an object

## Testing
- `PYTHONPATH=. pytest tests/test_manifest.py::test_launch_handler_is_object -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465bcc6850832ba61328d23250a080