### PR TITLE
Add PWA file handlers

### DIFF
--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -33,6 +33,15 @@
         "sizes": "180x180",
         "type": "image/png"
       }
+    ],
+    "file_handlers": [
+      {
+        "action": "/",
+        "name": "Image files",
+        "accept": {
+          "image/*": [".png", ".jpg", ".jpeg", ".webp"]
+        }
+      }
     ]
   }
   

--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -20,3 +20,11 @@ This application exposes basic Progressive Web App (PWA) features and can also b
   ```
 
 The fingerprint will be inserted into the generated `assetlinks.json` response at runtime.
+
+## File Handlers
+
+The manifest supports the `file_handlers` property so the application can register
+itself as the default handler for specific file types. By default, the provided
+manifest declares support for common image formats. When a user chooses
+"Always open with QuestByCycle" for a supported image, the site will launch to
+`/` where the uploaded file can be processed.

--- a/manifest.json
+++ b/manifest.json
@@ -38,5 +38,14 @@
             "sizes": "180x180",
             "type": "image/png"
         }
+    ],
+    "file_handlers": [
+        {
+            "action": "/",
+            "name": "Image files",
+            "accept": {
+                "image/*": [".png", ".jpg", ".jpeg", ".webp"]
+            }
+        }
     ]
 }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -24,3 +24,4 @@ def test_manifest_route(client):
     assert resp.mimetype == 'application/json'
     data = resp.get_json()
     assert data.get('name') == 'QuestByCycle'
+    assert 'file_handlers' in data


### PR DESCRIPTION
## Summary
- support PWA file handlers in manifest.json
- document file_handlers usage
- test for the new manifest field

## Testing
- `PYTHONPATH=. poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465c440d28832b879d15e5d752afca