### PR TITLE
Fix submission fetch function clash

### DIFF
--- a/app/static/js/quest_detail_modal.js
+++ b/app/static/js/quest_detail_modal.js
@@ -45,7 +45,7 @@ function openQuestDetailModal(questId) {
 
       openModal('questDetailModal');
       lazyLoadImages();
-      fetchSubmissions(questId);
+      fetchQuestSubmissions(questId);
     })
     .catch(err => {
       console.error('Error opening quest detail modal:', err);
@@ -79,7 +79,7 @@ function refreshQuestDetailModal(questId) {
       );
 
       lazyLoadImages();
-      fetchSubmissions(questId);
+      fetchQuestSubmissions(questId);
     })
     .catch(err => {
       console.error('Failed to refresh quest detail modal:', err);
@@ -458,9 +458,9 @@ async function submitQuestDetails(event, questId) {
 }
 
 /**********************************************************************
- *  2. fetchSubmissions                                               *
+ *  2. fetchQuestSubmissions                                          *
  **********************************************************************/
-async function fetchSubmissions(questId) {
+async function fetchQuestSubmissions(questId) {
   try {
     const res = await fetch(`/quests/quest/${questId}/submissions`, {
       method:      'GET',


### PR DESCRIPTION
## Summary
- avoid global name collision between `quest_detail_modal` and `all_submissions_modal` by renaming quest detail function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68465da39a70832ba3521a04ee1ed517