### PR TITLE
Add custom protocol handler

### DIFF
--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -33,6 +33,12 @@
         "sizes": "180x180",
         "type": "image/png"
       }
-    ]
+    ],
+  "protocol_handlers": [
+    {
+      "protocol": "web+questbycycle",
+      "url": "/protocol-handler?url=%s"
+    }
+  ]
   }
   

--- a/manifest.json
+++ b/manifest.json
@@ -38,5 +38,11 @@
             "sizes": "180x180",
             "type": "image/png"
         }
+    ],
+    "protocol_handlers": [
+        {
+            "protocol": "web+questbycycle",
+            "url": "/protocol-handler?url=%s"
+        }
     ]
 }

--- a/tests/test_protocol_handler.py
+++ b/tests/test_protocol_handler.py
@@ -1,0 +1,23 @@
+import pytest
+from app import create_app
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+    ctx.pop()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_protocol_handler_redirect(client):
+    resp = client.get('/protocol-handler', query_string={'url': 'web+questbycycle:1'})
+    assert resp.status_code == 302
+    assert '/quests/quest/1' in resp.headers['Location']


### PR DESCRIPTION
## Summary
- support `web+questbycycle:` links via new `/protocol-handler` route
- register protocol handler in the PWA manifests
- test redirect behavior for the custom protocol

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68465c522ad8832b9fb02672515c86f1