### PR TITLE
Add Web Share Target support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,8 +9,18 @@ import io
 import logging
 import os
 import json
-from flask import (Blueprint, jsonify, render_template, request, redirect,
-                   url_for, flash, current_app, send_file)
+from flask import (
+    Blueprint,
+    jsonify,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    current_app,
+    send_file,
+)
+from werkzeug.utils import secure_filename
 from flask_login import current_user, login_required
 from flask_wtf.csrf import generate_csrf
 from sqlalchemy import func
@@ -917,6 +927,22 @@ def manifest():
 def offline_page():
     """Return the offline fallback page."""
     return current_app.send_static_file('offline.html')
+
+
+@main_bp.route('/share-target', methods=['POST'])
+def share_target_handler():
+    """Handle incoming data from the Web Share Target API."""
+    file = request.files.get('file')
+    text = request.form.get('text')
+    title = request.form.get('title')
+    if file:
+        upload_dir = current_app.config.get('UPLOAD_FOLDER', '/tmp')
+        os.makedirs(upload_dir, exist_ok=True)
+        filename = secure_filename(file.filename)
+        file.save(os.path.join(upload_dir, filename))
+    if text or title:
+        flash('Shared content received.', 'success')
+    return redirect(url_for('main.index'))
 
 
 @main_bp.route('/.well-known/assetlinks.json')

--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -33,6 +33,21 @@
         "sizes": "180x180",
         "type": "image/png"
       }
-    ]
+    ],
+    "share_target": {
+      "action": "/share-target",
+      "method": "POST",
+      "enctype": "multipart/form-data",
+      "params": {
+        "title": "title",
+        "text": "text",
+        "files": [
+          {
+            "name": "file",
+            "accept": ["image/*"]
+          }
+        ]
+      }
+    }
   }
   

--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -6,6 +6,9 @@ This application exposes basic Progressive Web App (PWA) features and can also b
 - The file `app/static/offline.html` is served at `/offline.html` when the service worker is registered.
 - The PWA manifest at `app/static/manifest.json` is available from `/manifest.json`.
 - The service worker is registered from the root path: `/sw.js`.
+- The manifest includes a `share_target` entry so the site can receive shared
+  images and text via the Web Share Target API. Shared data is POSTed to the
+  route `/share-target`.
 
 ## TWA Asset Links
 - The route `/.well-known/assetlinks.json` dynamically returns the digital asset links used for TWA verification.

--- a/manifest.json
+++ b/manifest.json
@@ -38,5 +38,20 @@
             "sizes": "180x180",
             "type": "image/png"
         }
-    ]
+    ],
+    "share_target": {
+        "action": "/share-target",
+        "method": "POST",
+        "enctype": "multipart/form-data",
+        "params": {
+            "title": "title",
+            "text": "text",
+            "files": [
+                {
+                    "name": "file",
+                    "accept": ["image/*"]
+                }
+            ]
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- include share_target in PWA manifests
- handle `/share-target` POST requests in `app.main`
- document share target endpoint

## Testing
- `poetry install`
- `PYTHONPATH=. poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465c5b8984832ba978c2a9e8995f83