### PR TITLE
Refactor JS utils for DRY

### DIFF
--- a/app/static/js/all_submissions_modal.js
+++ b/app/static/js/all_submissions_modal.js
@@ -141,7 +141,7 @@ function deleteSubmission(submissionId) {
     fetch(`/quests/quest/delete_submission/${submissionId}`, {
         method: 'DELETE',
         headers: {
-            'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+            'X-CSRF-Token': getCSRFToken()
         }
     })
         .then(response => response.json())

--- a/app/static/js/badge_management.js
+++ b/app/static/js/badge_management.js
@@ -161,7 +161,7 @@ function deleteBadge(badgeId) {
     fetch(`/badges/delete/${badgeId}`, {
         method: 'DELETE',
         headers: {
-            'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+            'X-CSRFToken': getCSRFToken(),
         },
     })
     .then(response => response.json())
@@ -184,7 +184,7 @@ function uploadImages() {
         method: 'POST',
         body: formData,
         headers: {
-            'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+            'X-CSRFToken': getCSRFToken(),
         },
     })
     .then(response => response.json())

--- a/app/static/js/manage_quests.js
+++ b/app/static/js/manage_quests.js
@@ -31,7 +31,7 @@
             method: 'POST',
             body: formData,
             headers: {
-                'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                'X-CSRF-Token': getCSRFToken(),
                 'Accept': 'application/json'
             },
         })
@@ -88,7 +88,7 @@
                     fetch(`/quests/game/${game_Id}/delete_all`, {
                         method: 'DELETE',
                         headers: {
-                            'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                            'X-CSRF-Token': getCSRFToken(),
                             'Accept': 'application/json',
                         },
                     })
@@ -282,7 +282,7 @@
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                'X-CSRF-Token': getCSRFToken(),
             },
             body: JSON.stringify(questData),
         })
@@ -361,7 +361,7 @@
         fetch(`/quests/quest/${questId}/delete`, {
             method: 'DELETE',
             headers: {
-                'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                'X-CSRF-Token': getCSRFToken(),
                 'Accept': 'application/json',
             },
         })
@@ -391,7 +391,7 @@
             method: 'POST',
             body: formData,
             headers: {
-                'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                'X-CSRF-Token': getCSRFToken(),
                 'Accept': 'application/json',
             },
         })

--- a/app/static/js/quest_detail_modal.js
+++ b/app/static/js/quest_detail_modal.js
@@ -9,7 +9,7 @@ function meta(name) {
 
 /*  Current user ID and CSRF token pulled from <meta> tags.           */
 var CURRENT_USER_ID = Number(meta('current-user-id') || 0);
-var CSRF_TOKEN      = meta('csrf-token');
+var CSRF_TOKEN      = getCSRFToken();
 var PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE || meta('placeholder-image');
 window.PLACEHOLDER_IMAGE = PLACEHOLDER_IMAGE;
 

--- a/app/static/js/submission_detail_modal.js
+++ b/app/static/js/submission_detail_modal.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
 
   const $    = s => document.querySelector(s);
-  const csrf = () => document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+  const csrf = () => getCSRFToken();
   const PLACEHOLDER_IMAGE = document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
 
   window.showSubmissionDetail = function(image) {

--- a/app/static/js/submit_photo.js
+++ b/app/static/js/submit_photo.js
@@ -28,7 +28,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const formData = new FormData(submitPhotoForm);
 
-        const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+        const csrfToken = getCSRFToken();
         formData.append('csrf_token', csrfToken);
 
         fetch(submitPhotoForm.action, {

--- a/app/static/js/user_profile_modal.js
+++ b/app/static/js/user_profile_modal.js
@@ -300,13 +300,12 @@ function showUserProfileModal(userId) {
 
         updateFollowButton();
         btn.onclick = async () => {
-          const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
           const action = following ? 'unfollow' : 'follow';
           const res = await fetch(`/profile/${data.user.username}/${action}`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              'X-CSRFToken': token
+              'X-CSRFToken': getCSRFToken()
             },
             credentials: 'same-origin'
           });
@@ -396,7 +395,7 @@ function saveProfile(userId) {
   fetch(`/profile/${userId}/edit`, {
     method: 'POST',
     headers: {
-      'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+      'X-CSRFToken': getCSRFToken()
     },
     body: formData
   })
@@ -433,7 +432,7 @@ function saveBike(userId) {
   fetch(`/profile/${userId}/edit-bike`, {
     method: 'POST',
     headers: {
-      'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+      'X-CSRFToken': getCSRFToken()
     },
     body: formData
   })
@@ -457,7 +456,7 @@ function deleteSubmission(submissionId, context, userId) {
   fetch(`/quests/quest/delete_submission/${submissionId}`, {
     method: 'DELETE',
     headers: {
-      'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+      'X-CSRF-Token': getCSRFToken()
     }
   })
     .then(r => r.json())
@@ -484,7 +483,7 @@ function deleteAccount() {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+      'X-CSRFToken': getCSRFToken()
     }
   })
     .then(response => {

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -1,0 +1,16 @@
+(function(window){
+  'use strict';
+
+  window.getCSRFToken = function() {
+    const el = document.querySelector('meta[name="csrf-token"]');
+    return el ? el.getAttribute('content') : '';
+  };
+
+  window.fetchJson = async function(url, options = {}) {
+    const opts = { credentials: 'same-origin', ...options };
+    const res = await fetch(url, opts);
+    const json = await res.json().catch(() => ({}));
+    return { status: res.status, json };
+  };
+
+})(window);

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -312,6 +312,7 @@
      data-messages='{{ get_flashed_messages(with_categories=true) | tojson }}'>
 </div>
 
+<script src="{{ url_for('static', filename='js/utils.js') }}" defer></script>
 <script src="{{ url_for('static', filename='js/modal_common.js') }}" defer></script>
 <script src="{{ url_for('static', filename='js/layout.js') }}" defer></script>
 <script src="{{ url_for('static', filename='js/push.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- introduce reusable `getCSRFToken` helper
- load new helper in layout
- use helper across modals and other JS modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846629b69b0832b95ac251d40da759a