### PR TITLE
Refactor SCSS flash messages

### DIFF
--- a/app/static/scss/abstracts/_mixins.scss
+++ b/app/static/scss/abstracts/_mixins.scss
@@ -6,10 +6,20 @@
   }
   
   // Mixin for CSS transitions (adds vendor prefix)
-  @mixin transition($properties...) {
-    -webkit-transition: $properties;
-    transition: $properties;
-  }
-  
-  // Example: @include transition(all 0.3s ease-in-out);
+@mixin transition($properties...) {
+  -webkit-transition: $properties;
+  transition: $properties;
+}
+
+// Example: @include transition(all 0.3s ease-in-out);
+
+// Mixin for flash message blocks
+@mixin flash-alert($bg, $text, $border) {
+  background-color: $bg;
+  color: $text;
+  border: 1px solid $border;
+  padding: 10px;
+  border-radius: 5px;
+  margin-bottom: 15px;
+}
   

--- a/app/static/scss/abstracts/_variables.scss
+++ b/app/static/scss/abstracts/_variables.scss
@@ -6,3 +6,22 @@ $body-bg: #fff;
 $font-stack: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
 $base-font-size: 16px;
 $border-radius: 0.25rem;
+
+// Flash message colors
+$flash-highlight-color: #edf944;
+
+$success-bg: #a8d5a3;
+$success-text: #3c763d;
+$success-border: #96c48b;
+
+$error-bg: #f7c6c6;
+$error-text: #a94442;
+$error-border: #f0a7a7;
+
+$warning-bg: #fae1b5;
+$warning-text: #8a6d3b;
+$warning-border: #f7d09a;
+
+$info-bg: #56cbdf;
+$info-text: #31708f;
+$info-border: #a3cbd3;

--- a/app/static/scss/components/_flash_messages.scss
+++ b/app/static/scss/components/_flash_messages.scss
@@ -1,49 +1,29 @@
 // Flash message styling ported from old CSS (main1.css)
 
 .flash-message {
-  background-color: #edf944;
+  background-color: $flash-highlight-color;
 }
 
 .flash-success {
-  background-color: #a8d5a3; /* Light green background */
-  color: #3c763d;            /* Dark green text */
-  border: 1px solid #96c48b;
-  padding: 10px;
-  border-radius: 5px;
-  margin-bottom: 15px;
+  @include flash-alert($success-bg, $success-text, $success-border);
 }
 
 .flash-error,
 .flash-danger {
-  background-color: #f7c6c6; /* Light red background */
-  color: #a94442;            /* Dark red text */
-  border: 1px solid #f0a7a7;
-  padding: 10px;
-  border-radius: 5px;
-  margin-bottom: 15px;
+  @include flash-alert($error-bg, $error-text, $error-border);
 }
 
 .flash-warning {
-  background-color: #fae1b5; /* Light orange background */
-  color: #8a6d3b;            /* Dark orange text */
-  border: 1px solid #f7d09a;
-  padding: 10px;
-  border-radius: 5px;
-  margin-bottom: 15px;
+  @include flash-alert($warning-bg, $warning-text, $warning-border);
 }
 
 .flash-info {
-  background-color: #56cbdf; /* Light blue background */
-  color: #31708f;            /* Dark blue text */
-  border: 1px solid #a3cbd3;
-  padding: 10px;
-  border-radius: 5px;
-  margin-bottom: 15px;
+  @include flash-alert($info-bg, $info-text, $info-border);
 }
 
 .blue_button {
-  background-color: #007bff;
-  color: white;
+  background-color: $primary-color;
+  color: $body-bg;
   border: none;
   padding: 10px 20px;
   border-radius: 5px;
@@ -52,5 +32,5 @@
 }
 
 .blue_button:hover {
-  background-color: #0056b3;
+  background-color: darken($primary-color, 10%);
 }


### PR DESCRIPTION
## Summary
- add color variables for flash messages
- add `flash-alert` mixin
- refactor flash message styles to use the mixin and variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684662a4ba34832ba61426cb049564af