### PR TITLE
Fix layout.js syntax error

### DIFF
--- a/app/static/js/layout.js
+++ b/app/static/js/layout.js
@@ -45,6 +45,7 @@ document.addEventListener('DOMContentLoaded', function() {
           if (Notification.permission === 'default') {
             Notification.requestPermission();
           }
+        }
 
         if ('sync' in registration) {
           registration.sync.register('sync-requests').catch(function(err) {


### PR DESCRIPTION
## Summary
- close the `PushManager` conditional block in layout.js to avoid unexpected token errors

## Testing
- `node --check app/static/js/layout.js`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684663458cec832b98e9b95d82571b3f