### PR TITLE
Refactor HTML templates for DRY assets

### DIFF
--- a/app/templates/add_quest.html
+++ b/app/templates/add_quest.html
@@ -92,5 +92,8 @@
     </form>
 </div>
 
+{% endblock %}
+
+{% block extra_scripts %}
 <script src="{{ url_for('static', filename='js/add_quest.js') }}"></script>
 {% endblock %}

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -70,11 +70,13 @@
 {% include 'modals/leaderboard_modal.html' %}
 {% include 'modals/delete_game_modal.html' %}
 
+{% endblock %}
+
+{% block extra_scripts %}
 <script src="{{ url_for('static', filename='js/all_submissions_modal.js') }}"></script>
 <script src="{{ url_for('static', filename='js/game_info_modal.js') }}"></script>
 <script src="{{ url_for('static', filename='js/user_profile_modal.js') }}"></script>
 <script src="{{ url_for('static', filename='js/leaderboard_modal.js') }}"></script>
 <script src="{{ url_for('static', filename='js/index_management.js') }}"></script>
 <script src="{{ url_for('static', filename='js/delete_game_modal.js') }}"></script>
-
 {% endblock %}

--- a/app/templates/create_game.html
+++ b/app/templates/create_game.html
@@ -174,6 +174,9 @@
     </form>
 </div>
 
-<script src="{{ url_for('static', filename='js/create_game.js') }}"></script>
 
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/create_game.js') }}"></script>
 {% endblock %}

--- a/app/templates/edit_sponsors.html
+++ b/app/templates/edit_sponsors.html
@@ -38,5 +38,8 @@
     </form>    
 </div>
 
+{% endblock %}
+
+{% block extra_scripts %}
 <script src="{{ url_for('static', filename='js/edit_sponsors.js') }}"></script>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -341,7 +341,14 @@
     {% include 'modals/generate_AI_quest_modal.html' %}
     {% include 'modals/sponsors_modal.html' %}
     {% include 'modals/reset_password_modal.html' %}
+
+{% endblock %}
+
+{% block extra_styles %}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/3rd/fontawesome/all.min.css') }}">
+{% endblock %}
+
+{% block extra_scripts %}
     <script src="{{ url_for('static', filename='js/shout_board_modal.js') }}"></script>
     <script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
     <script src="{{ url_for('static', filename='js/badge_modal.js') }}"></script>
@@ -353,5 +360,4 @@
     <script src="{{ url_for('static', filename='js/user_profile_modal.js') }}"></script>
     <script src="{{ url_for('static', filename='js/index_management.js') }}"></script>
     <script src="{{ url_for('static', filename='js/generated_quest.js') }}"></script>
-
 {% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -60,6 +60,8 @@
   <link rel="preload" href="{{ url_for('static', filename='css/atom-one-dark.min.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="{{ url_for('static', filename='css/atom-one-dark.min.css') }}"></noscript>
 
+  {# Block for page-specific stylesheets #}
+  {% block extra_styles %}{% endblock %}
 
   <meta name="csrf-token" content="{{ csrf_token() }}">
   <meta name="current-user-id" content="{{ current_user.id }}">
@@ -318,6 +320,8 @@
 <script src="{{ url_for('static', filename='js/push.js') }}" defer></script>
 
 <script src="{{ url_for('static', filename='js/flash_modal.js') }}" defer></script>
+
+{% block extra_scripts %}{% endblock %}
 
 </body>
 </html>

--- a/app/templates/manage_badges.html
+++ b/app/templates/manage_badges.html
@@ -113,5 +113,8 @@
         </table>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_scripts %}
 <script src="{{ url_for('static', filename='js/badge_management.js') }}"></script>
 {% endblock %}

--- a/app/templates/manage_quests.html
+++ b/app/templates/manage_quests.html
@@ -46,5 +46,8 @@
     </div>
 </div>
 
+{% endblock %}
+
+{% block extra_scripts %}
 <script src="{{ url_for('static', filename='js/manage_quests.js') }}"></script>
 {% endblock %}

--- a/app/templates/manage_sponsors.html
+++ b/app/templates/manage_sponsors.html
@@ -54,7 +54,8 @@
     </div>
 </div>
 
+{% endblock %}
+
+{% block extra_scripts %}
 <script src="{{ url_for('static', filename='js/manage_sponsors.js') }}"></script>
-
-
 {% endblock %}

--- a/app/templates/update_game.html
+++ b/app/templates/update_game.html
@@ -140,6 +140,9 @@
 </div>
 
 
-<script src="{{ url_for('static', filename='js/create_game.js') }}"></script>
 
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/create_game.js') }}"></script>
 {% endblock %}

--- a/app/templates/user_management.html
+++ b/app/templates/user_management.html
@@ -78,5 +78,8 @@
     </div>
 </div>
 
+{% endblock %}
+
+{% block extra_scripts %}
 <script src="{{ url_for('static', filename='js/user_management.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `extra_styles` and `extra_scripts` blocks to the main layout
- move page specific assets into new blocks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for app)*

------
https://chatgpt.com/codex/tasks/task_e_684664c2df38832b8370bece7845c70d