### PR TITLE
Fix CodeQL DOM injection warnings

### DIFF
--- a/app/static/js/badge_management.js
+++ b/app/static/js/badge_management.js
@@ -45,28 +45,39 @@ function setCategoryOptions(currentCategory) {
         .then(response => response.json())
         .then(data => {
             const categories = data.categories || [];
-            
-            // Build the <option> elements
-            let options = categories.map(category => {
-                let selected = (category === currentCategory) ? 'selected' : '';
-                return `<option value="${category}" ${selected}>${category}</option>`;
+            const select = document.createElement('select');
+            select.className = 'form-control badge-category-select';
+
+            const noneOption = document.createElement('option');
+            noneOption.value = 'none';
+            noneOption.textContent = 'None';
+            if (!currentCategory || currentCategory === 'none') {
+                noneOption.selected = true;
+            }
+            select.appendChild(noneOption);
+
+            categories.forEach(category => {
+                const opt = document.createElement('option');
+                opt.value = category;
+                opt.textContent = category;
+                if (category === currentCategory) {
+                    opt.selected = true;
+                }
+                select.appendChild(opt);
             });
 
-            // Add a "None" option at the beginning
-            let selectedNone = (!currentCategory || currentCategory === 'none') ? 'selected' : '';
-            options.unshift(`<option value="none" ${selectedNone}>None</option>`);
-
-            // Return a fully formed <select> element
-            return `<select class="form-control badge-category-select">
-                        ${options.join('')}
-                    </select>`;
+            return select;
         })
         .catch(error => {
             console.error('Error fetching categories:', error);
-            // Fallback: Display "None" if there's an error
-            return `<select class="form-control badge-category-select">
-                        <option value="none" selected>None</option>
-                    </select>`;
+            const select = document.createElement('select');
+            select.className = 'form-control badge-category-select';
+            const noneOption = document.createElement('option');
+            noneOption.value = 'none';
+            noneOption.textContent = 'None';
+            noneOption.selected = true;
+            select.appendChild(noneOption);
+            return select;
         });
 }
 
@@ -84,33 +95,37 @@ function editBadge(badgeId) {
     const imageContainer = row.querySelector('.badge-image-manage');
 
     // 1) Replace the name cell
-    nameCell.innerHTML = `
-        <input type="text"
-               value="${nameCell.innerText.trim()}"
-               class="form-control badge-name-input">
-    `;
+    nameCell.textContent = '';
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.value = nameCell.innerText.trim();
+    nameInput.className = 'form-control badge-name-input';
+    nameCell.appendChild(nameInput);
 
     // 2) Replace the description cell
-    descriptionCell.innerHTML = `
-        <textarea class="form-control badge-description-textarea">
-            ${descriptionCell.innerText.trim()}
-        </textarea>
-    `;
+    descriptionCell.textContent = '';
+    const descTextarea = document.createElement('textarea');
+    descTextarea.className = 'form-control badge-description-textarea';
+    descTextarea.value = descriptionCell.innerText.trim();
+    descriptionCell.appendChild(descTextarea);
 
     // 3) Replace or remove the existing <img>
     //    Then inject a file input
     if (imageContainer) {
         // Clear out existing content (be it "No Image" text or <img> tag)
-        imageContainer.innerHTML = `
-            <input type="file" class="form-control-file badge-image-input">
-        `;
+        imageContainer.textContent = '';
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.className = 'form-control-file badge-image-input';
+        imageContainer.appendChild(fileInput);
     } else {
         console.error('Could not find badge-image-manage cell');
     }
 
     // 4) Call setCategoryOptions(...) to build the <select> for Category
-    setCategoryOptions(categoryCell.innerText.trim()).then(categoryHtml => {
-        categoryCell.innerHTML = categoryHtml;
+    setCategoryOptions(categoryCell.innerText.trim()).then(selectEl => {
+        categoryCell.textContent = '';
+        categoryCell.appendChild(selectEl);
 
         // 5) Change the button label to "Save" and hook up the saveBadge call
         const editButton = row.querySelector('button.edit-badge');

--- a/app/static/js/badge_modal.js
+++ b/app/static/js/badge_modal.js
@@ -63,7 +63,7 @@ async function ensureBadgeCache() {
 function buildTaskListHTML(taskNames) {
   if (!taskNames) return '';
   const tasks = taskNames.split(',');
-  return `<ul>${tasks.map(task => `<li>${task.trim()}</li>`).join('')}</ul>`;
+  return `<ul>${tasks.map(task => `<li>${escapeHTML(task.trim())}</li>`).join('')}</ul>`;
 }
 
 function findBadgeById(badgeId) {

--- a/app/static/js/badge_modal.js
+++ b/app/static/js/badge_modal.js
@@ -98,7 +98,7 @@ function populateBadgeModal(badge, requiredCount, currentUserCompletions, taskLi
 
   let badgeSpecificText = '';
   if (taskId) {
-    const taskLink = `<a href="#" onclick="openQuestDetailModal('${taskId}')">${taskNames}</a>`;
+    const taskLink = `<a href="#" onclick="openQuestDetailModal('${taskId}')">${escapeHTML(taskNames)}</a>`;
     badgeSpecificText = `<p>Completion Requirement: ${requiredCount > 1 ? requiredCount + ' times' : requiredCount + ' time'}</p>` +
                         `<p>Your Total Completions: ${currentUserCompletions}</p>` +
                         `<p>${earned ? 'You have earned this badge.' : 'Complete ' + taskLink + ' to earn this badge.'}</p>`;
@@ -113,14 +113,14 @@ function populateBadgeModal(badge, requiredCount, currentUserCompletions, taskLi
   if (earned) {
     modalImage.style.filter = 'none';
     modalImage.oncontextmenu = null;
-    modalText.innerHTML = `<p><strong>Awarded!</strong></p>${badgeSpecificText}<p>${descriptionText}</p>`;
+    modalText.innerHTML = `<p><strong>Awarded!</strong></p>${badgeSpecificText}<p>${escapeHTML(descriptionText)}</p>`;
   } else {
     modalImage.style.filter = 'grayscale(100%) opacity(0.5)';
     modalImage.oncontextmenu = e => {
       e.preventDefault();
       return false;
     };
-    modalText.innerHTML = `<p><strong>Not Awarded Yet</strong></p>${badgeSpecificText}<p>${descriptionText}</p>`;
+    modalText.innerHTML = `<p><strong>Not Awarded Yet</strong></p>${badgeSpecificText}<p>${escapeHTML(descriptionText)}</p>`;
   }
 }
 

--- a/app/static/js/manage_quests.js
+++ b/app/static/js/manage_quests.js
@@ -198,7 +198,7 @@
         } else if (field.type === "textarea") {
             inputElement = document.createElement("textarea");
             inputElement.name = field.name;
-            inputElement.innerHTML = currentValue;
+            inputElement.value = currentValue;
         } else {
             inputElement = document.createElement("input");
             inputElement.type = field.type;

--- a/app/static/js/quest_detail_modal.js
+++ b/app/static/js/quest_detail_modal.js
@@ -129,8 +129,8 @@ function populateQuestDetails(quest, userCompletionCount, canVerify, questId, ne
     }
 
     elements['modalQuestTitle'].innerText = `${quest.title}${completeText}`;
-    elements['modalQuestDescription'].innerHTML = quest.description;
-    elements['modalQuestTips'].innerHTML = quest.tips || 'No tips available';
+    elements['modalQuestDescription'].textContent = quest.description;
+    elements['modalQuestTips'].textContent = quest.tips || 'No tips available';
     elements['modalQuestPoints'].innerText = `${quest.points}`;
     elements['modalQuestCategory'].innerText = quest.category || 'No category set';
     

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -13,4 +13,13 @@
     return { status: res.status, json };
   };
 
+  window.escapeHTML = function(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  };
+
 })(window);


### PR DESCRIPTION
## Summary
- sanitize HTML usage when populating the badge modal
- avoid innerHTML when editing badges and fetching quest data
- ensure textareas set values safely
- add a global `escapeHTML` utility

## Testing
- `poetry run pytest -q tests/test_manage_quests_logic.py`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684667408610832b9b1188062308c259