### PR TITLE
Fix service worker cross-origin handling

### DIFF
--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -166,6 +166,11 @@ function shouldCacheRequest(request) {
 
 // Fetch event with offline fallback
 self.addEventListener("fetch", (event) => {
+  const requestUrl = new URL(event.request.url);
+  // Skip cross-origin requests entirely so the browser handles them.
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
   // Queue non-GET requests when offline
   if (["POST", "PUT", "DELETE"].includes(event.request.method)) {
     event.respondWith(
@@ -216,7 +221,8 @@ self.addEventListener("fetch", (event) => {
         return networkResponse;
       } catch (error) {
         console.error("Fetch failed; returning offline page instead.", error);
-        return caches.match("/offline.html");
+        const offlineResponse = await caches.match("/offline.html");
+        return offlineResponse || Response.error();
       }
     })()
   );

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -345,7 +345,7 @@
 {% endblock %}
 
 {% block extra_styles %}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@6.6.0/css/all.min.css">
 {% endblock %}
 
 {% block extra_scripts %}


### PR DESCRIPTION
## Summary
- avoid intercepting cross-origin requests in the service worker
- return an error response when the offline page is missing
- load Font Awesome from jsDelivr to comply with CSP rules

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68466baea604832baced8fdf3549adba