### PR TITLE
Fix local ActivityPub actor URL

### DIFF
--- a/app/activitypub_utils.py
+++ b/app/activitypub_utils.py
@@ -426,6 +426,13 @@ def create_activitypub_actor(user):
     if not user.activitypub_id:
         public_pem, private_pem = generate_activitypub_keys()
         actor_url = url_for('activitypub.view_user', username=user.username, _external=True)
+        parsed = urlparse(actor_url)
+        domain = current_app.config.get("LOCAL_DOMAIN")
+        if not domain:
+            raise RuntimeError("LOCAL_DOMAIN must be configured for ActivityPub")
+        if parsed.netloc != domain:
+            actor_url = f"https://{domain}/users/{user.username}"
+
         user.activitypub_id = actor_url
         user.public_key = public_pem
         user.private_key = private_pem

--- a/tests/test_activitypub_delivery.py
+++ b/tests/test_activitypub_delivery.py
@@ -7,6 +7,7 @@ from app.activitypub_utils import (
     deliver_activity,
     generate_activitypub_keys,
     sign_activitypub_request,
+    create_activitypub_actor,
 )
 
 
@@ -79,3 +80,18 @@ def test_sign_request_returns_string(app):
         "{}",
     )
     assert isinstance(headers["Signature"], str)
+
+def test_create_actor_uses_local_domain_when_server_name_blank(app):
+    app.config["SERVER_NAME"] = ""
+    user = User(
+        username="fall",
+        email="fall@example.com",
+        license_agreed=True,
+        email_verified=True,
+    )
+    db.session.add(user)
+    db.session.commit()
+
+    create_activitypub_actor(user)
+
+    assert user.activitypub_id == "https://example.com/users/fall"


### PR DESCRIPTION
## Summary
- handle missing SERVER_NAME in `create_activitypub_actor`
- test fallback to `LOCAL_DOMAIN`

## Testing
- `pytest tests/test_activitypub_delivery.py::test_create_actor_uses_local_domain_when_server_name_blank -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466ff8ac88832ba8eab904fde9def5