### PR TITLE
Fix service worker sync errors

### DIFF
--- a/app/static/js/layout.js
+++ b/app/static/js/layout.js
@@ -27,7 +27,9 @@ document.addEventListener('DOMContentLoaded', function() {
           registration.sync
             .register('sync-notifications')
             .catch(function(err) {
-              console.error('Sync registration failed:', err);
+              if (err && err.name !== 'NotAllowedError') {
+                console.error('Sync registration failed:', err);
+              }
             });
         }
 
@@ -36,7 +38,9 @@ document.addEventListener('DOMContentLoaded', function() {
           registration.periodicSync
             .register('periodic-notifications', { minInterval: 24 * 60 * 60 * 1000 })
             .catch(function(err) {
-              console.error('Periodic sync registration failed:', err);
+              if (err && err.name !== 'NotAllowedError') {
+                console.error('Periodic sync registration failed:', err);
+              }
             });
         }
 
@@ -49,7 +53,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
         if ('sync' in registration) {
           registration.sync.register('sync-requests').catch(function(err) {
-            console.error('Background sync registration failed:', err);
+            if (err && err.name !== 'NotAllowedError') {
+              console.error('Background sync registration failed:', err);
+            }
           });
         }
       })

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -215,8 +215,12 @@ self.addEventListener("fetch", (event) => {
           return cachedResponse;
         }
         const networkResponse = await fetch(event.request);
-        if (shouldCacheRequest(event.request)) {
-          cache.put(event.request, networkResponse.clone());
+        if (shouldCacheRequest(event.request) && networkResponse.status !== 206) {
+          try {
+            cache.put(event.request, networkResponse.clone());
+          } catch (err) {
+            console.error("Cache put failed:", err);
+          }
         }
         return networkResponse;
       } catch (error) {


### PR DESCRIPTION
## Summary
- handle NotAllowedError during background sync registration
- avoid caching partial responses in service worker

## Testing
- `PYTHONPATH=$(pwd) poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467111c110832b93b78683ed9b0f83