### PR TITLE
Fix CDN resource paths

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -345,7 +345,7 @@
 {% endblock %}
 
 {% block extra_styles %}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@6.6.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.6.0/css/all.min.css">
 {% endblock %}
 
 {% block extra_scripts %}{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -57,8 +57,8 @@
   <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.snow.css"></noscript>
   <link rel="preload" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css"></noscript>
-  <link rel="preload" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/atom-one-dark.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/atom-one-dark.min.css"></noscript>
+  <link rel="preload" href="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.9.0/styles/atom-one-dark.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.9.0/styles/atom-one-dark.min.css"></noscript>
 
   {# Block for page-specific stylesheets #}
   {% block extra_styles %}{% endblock %}
@@ -70,10 +70,9 @@
   <!-- JavaScript -->
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/dist/highlight.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.9.0/highlight.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.min.js"></script>
-  <script src="{{ url_for('static', filename='js/quill_common.js') }}"></script>
   <script type="module" src="{{ url_for('static', filename='dist/main.js') }}"></script>
 </head>
 


### PR DESCRIPTION
## Summary
- fix highlight.js script link
- remove reference to quill_common.js
- correct Font Awesome CDN path

## Testing
- `PYTHONPATH=. poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684679ab0fc8832ba995e5fe1ffc811d