### PR TITLE
Add front-end length validation for shout board admin posts

### DIFF
--- a/frontend/modules/shout_board_modal.js
+++ b/frontend/modules/shout_board_modal.js
@@ -35,6 +35,12 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    const plainText = quill.getText().trim();
+    if (plainText.length > 500) {
+      alert('Message must be 500 characters or fewer.');
+      return;
+    }
+
     document.getElementById('shoutMessageInput').value = html;
 
     const data = new FormData(formEl);


### PR DESCRIPTION
## Summary
- check Quill plain text length before submitting shout board post

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68467c2c6cd4832ba6ac56eaad678af1