### PR TITLE
Address ESLint notes on ESM config and scripts

### DIFF
--- a/frontend/modules/add_quest.js
+++ b/frontend/modules/add_quest.js
@@ -1,21 +1,18 @@
-var quillDescription = initQuill('#description-editor');
-var quillTips        = initQuill('#tips-editor');
+const quillDescription = initQuill('#description-editor');
+const quillTips = initQuill('#tips-editor');
 
-document.getElementById('quest-form').onsubmit = function(e) {
-    // Get the Quill editor contents
-    var descriptionContent = quillDescription.root.innerHTML.trim();
-    var tipsContent = quillTips.root.innerHTML.trim();
+document.getElementById('quest-form')?.addEventListener('submit', e => {
+  const descriptionContent = quillDescription.root.innerHTML.trim();
+  const tipsContent = quillTips.root.innerHTML.trim();
 
-    // Check if the Quill editor content is empty
-    if (!descriptionContent || descriptionContent === '<p><br></p>') {
-        alert('Description is required.');
-        e.preventDefault();  // Prevent the form from submitting
-        return false;
-    }
+  if (!descriptionContent || descriptionContent === '<p><br></p>') {
+    alert('Description is required.');
+    e.preventDefault();
+    return false;
+  }
 
-    // Set the hidden textarea value
-    document.getElementById('description').value = descriptionContent;
-    document.getElementById('tips').value = tipsContent;
-};
+  document.getElementById('description').value = descriptionContent;
+  document.getElementById('tips').value = tipsContent;
+});
 
 export {};

--- a/frontend/modules/all_submissions_modal.js
+++ b/frontend/modules/all_submissions_modal.js
@@ -1,6 +1,7 @@
 
-var PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE ||
-    document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
+const PLACEHOLDER_IMAGE =
+  window.PLACEHOLDER_IMAGE ||
+  document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
 window.PLACEHOLDER_IMAGE = PLACEHOLDER_IMAGE;
 
 let submissionsPage = 0;

--- a/frontend/modules/badge_management.js
+++ b/frontend/modules/badge_management.js
@@ -32,12 +32,9 @@ function loadBadges() {
 }
 
 function toggleForm(formId) {
-    var form = document.getElementById(formId);
-    if (form.style.display === "none") {
-        form.style.display = "block";
-    } else {
-        form.style.display = "none";
-    }
+  const form = document.getElementById(formId);
+  if (!form) return;
+  form.style.display = form.style.display === 'none' ? 'block' : 'none';
 }
 
 function setCategoryOptions(currentCategory) {

--- a/frontend/modules/badge_modal.js
+++ b/frontend/modules/badge_modal.js
@@ -2,8 +2,9 @@
 
 // Cache all badges in a global variable once loaded
 window.allBadges = window.allBadges || [];
-var PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE ||
-    document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
+const PLACEHOLDER_IMAGE =
+  window.PLACEHOLDER_IMAGE ||
+  document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
 window.PLACEHOLDER_IMAGE = PLACEHOLDER_IMAGE;
 
 /**

--- a/frontend/modules/index_management.js
+++ b/frontend/modules/index_management.js
@@ -24,10 +24,13 @@ const updateMeter = async gameId => {
     const remainingPoints = gameGoal - totalPoints;
     const heightPercent   = Math.min((totalPoints / gameGoal) * 100, 100);
 
-    document.getElementById('meterBar').style.height = `${heightPercent}%`;
+    const meterBar = document.getElementById('meterBar');
+    const label = document.querySelector('.meter-label');
+    if (meterBar) meterBar.style.height = `${heightPercent}%`;
     document.documentElement.style.setProperty('--meter-fill-height', `${heightPercent}%`);
-    document.querySelector('.meter-label').innerText =
-      `Remaining Reduction: ${remainingPoints} / ${gameGoal}`;
+    if (label) {
+      label.innerText = `Remaining Reduction: ${remainingPoints} / ${gameGoal}`;
+    }
   } catch (err) {
     console.error('Failed to update meter:', err);
   }

--- a/frontend/modules/push.js
+++ b/frontend/modules/push.js
@@ -1,5 +1,10 @@
 document.addEventListener('DOMContentLoaded', () => {
-  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+  if (
+    typeof window === 'undefined' ||
+    typeof navigator === 'undefined' ||
+    !('serviceWorker' in navigator) ||
+    !('PushManager' in window)
+  ) {
     return;
   }
 

--- a/frontend/modules/quest_detail_modal.js
+++ b/frontend/modules/quest_detail_modal.js
@@ -8,9 +8,9 @@ function meta(name) {
 }
 
 /*  Current user ID and CSRF token pulled from <meta> tags.           */
-var CURRENT_USER_ID = Number(meta('current-user-id') || 0);
-var CSRF_TOKEN      = getCSRFToken();
-var PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE || meta('placeholder-image');
+const CURRENT_USER_ID = Number(meta('current-user-id') || 0);
+const CSRF_TOKEN = getCSRFToken();
+const PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE || meta('placeholder-image');
 window.PLACEHOLDER_IMAGE = PLACEHOLDER_IMAGE;
 
 /* ------------------------------------------------------------------ */

--- a/frontend/modules/user_management.js
+++ b/frontend/modules/user_management.js
@@ -1,10 +1,10 @@
-document.getElementById('gameFilter').addEventListener('change', function() {
-    var gameId = this.value;
-    if (gameId) {
-        window.location.href = '/admin/user_management/game/' + gameId;
-    } else {
-        window.location.href = '/admin/user_management';
-    }
+document.getElementById('gameFilter')?.addEventListener('change', function () {
+  const gameId = this.value;
+  if (gameId) {
+    window.location.href = `/admin/user_management/game/${gameId}`;
+  } else {
+    window.location.href = '/admin/user_management';
+  }
 });
 
 export {};

--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -20,6 +20,8 @@ export function escapeHTML(str) {
 }
 
 // backwards compatibility
-window.getCSRFToken = getCSRFToken;
-window.fetchJson = fetchJson;
-window.escapeHTML = escapeHTML;
+if (typeof window !== 'undefined') {
+  window.getCSRFToken = getCSRFToken;
+  window.fetchJson = fetchJson;
+  window.escapeHTML = escapeHTML;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vite';
-import { resolve } from 'path';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   build: {


### PR DESCRIPTION
## Summary
- fix Vite config for ESM by deriving `__dirname` from `import.meta.url`
- export helper functions only when `window` exists
- modernize `add_quest` and `user_management` modules
- make badge management toggle resilient to missing form element
- check for DOM elements when updating meter bar
- guard push notification logic for server-side contexts
- switch remaining `var` declarations to `const`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684683788bb0832b8ee05e5824b9a4eb