### PR TITLE
Fix login/register modal fallback

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -228,10 +228,18 @@
               {% else %}
                 <!-- For non-authenticated users -->
                 <li class="nav-item">
-                    <a href="javascript:void(0)" class="btn btn-secondary btn-lg" onclick="openModal('loginModal')">Login</a>
+                    <a href="{{ url_for('auth.login') }}"
+                       class="btn btn-secondary btn-lg"
+                       onclick="if (typeof window.openModal === 'function' && document.getElementById('loginModal')) { event.preventDefault(); openModal('loginModal'); }">
+                      Login
+                    </a>
                 </li>
                 <li class="nav-item">
-                    <a href="javascript:void(0)" class="btn btn-primary btn-lg" onclick="openModal('registerModal')">Register Today!</a>
+                    <a href="{{ url_for('auth.register') }}"
+                       class="btn btn-primary btn-lg"
+                       onclick="if (typeof window.openModal === 'function' && document.getElementById('registerModal')) { event.preventDefault(); openModal('registerModal'); }">
+                      Register Today!
+                    </a>
                 </li>
               {% endif %}
           </ul>


### PR DESCRIPTION
## Summary
- open login/register modal only when available
- otherwise fall back to full page login/register routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846864cddb4832bbb728f41d1760f59