### PR TITLE
Fix Quill initialization on missing editors

### DIFF
--- a/frontend/modules/add_quest.js
+++ b/frontend/modules/add_quest.js
@@ -1,18 +1,26 @@
 import { initQuill } from './quill_common.js';
-const quillDescription = initQuill('#description-editor');
-const quillTips = initQuill('#tips-editor');
 
-document.getElementById('quest-form')?.addEventListener('submit', e => {
-  const descriptionContent = quillDescription.root.innerHTML.trim();
-  const tipsContent = quillTips.root.innerHTML.trim();
+// Only initialise the editors when the elements exist on the page.
+const descriptionEl = document.querySelector('#description-editor');
+const tipsEl        = document.querySelector('#tips-editor');
 
-  if (!descriptionContent || descriptionContent === '<p><br></p>') {
-    alert('Description is required.');
-    e.preventDefault();
-    return false;
-  }
+const quillDescription = descriptionEl ? initQuill(descriptionEl) : null;
+const quillTips        = tipsEl ? initQuill(tipsEl) : null;
 
-  document.getElementById('description').value = descriptionContent;
-  document.getElementById('tips').value = tipsContent;
-});
+const questForm = document.getElementById('quest-form');
+if (questForm && quillDescription && quillTips) {
+  questForm.addEventListener('submit', e => {
+    const descriptionContent = quillDescription.root.innerHTML.trim();
+    const tipsContent        = quillTips.root.innerHTML.trim();
+
+    if (!descriptionContent || descriptionContent === '<p><br></p>') {
+      alert('Description is required.');
+      e.preventDefault();
+      return false;
+    }
+
+    document.getElementById('description').value = descriptionContent;
+    document.getElementById('tips').value        = tipsContent;
+  });
+}
 


### PR DESCRIPTION
## Summary
- avoid TypeError when `#description-editor` or `#tips-editor` are absent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684691296b40832bbd3bc9a25d62d7c6