### PR TITLE
Add leaderboard quest completion toggle

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -517,7 +517,10 @@ def leaderboard_partial():
             User.id,
             User.username,
             User.display_name,
-            db.func.sum(UserQuest.points_awarded).label('total_points')
+            db.func.sum(UserQuest.points_awarded).label('total_points'),
+            db.func.sum(
+                db.case([(UserQuest.completions > 0, 1)], else_=0)
+            ).label('completed_quests')
         ).join(UserQuest, UserQuest.user_id == User.id
         ).join(Quest, Quest.id == UserQuest.quest_id
         ).filter(Quest.game_id == selected_game_id
@@ -529,8 +532,9 @@ def leaderboard_partial():
             'user_id': uid,
             'username': username,
             'display_name': display_name,
-            'total_points': total_points
-        } for uid, username, display_name, total_points in top_users_query]
+            'total_points': total_points,
+            'completed_quests': completed_quests
+        } for uid, username, display_name, total_points, completed_quests in top_users_query]
 
         total_game_points = db.session.query(
             db.func.sum(UserQuest.points_awarded)


### PR DESCRIPTION
## Summary
- include quest completion count in leaderboard endpoint
- add frontend toggle to swap leaderboard between points and quests completed
- rebuild frontend assets

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684691f5806c832bbccb2e55ad939814