### PR TITLE
Add mastodon login modal and enforce terms on sign in

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -333,9 +333,9 @@ def login():
     form    = LoginForm()
     is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
 
-                                          
+
     if not form.validate_on_submit():
-        msg = 'Please enter both email and password.'
+        msg = 'Please correct the errors in the login form.'
         if is_ajax:
             return jsonify({
                 'success': False,

--- a/app/forms.py
+++ b/app/forms.py
@@ -76,7 +76,15 @@ class RegistrationForm(FlaskForm):
 class MastodonLoginForm(FlaskForm):
     """Form for logging in via Mastodon OAuth."""
     instance = StringField("Mastodon Instance Domain", validators=[DataRequired()])
+    accept_license = BooleanField("I agree to the ", validators=[DataRequired()])
     submit = SubmitField("Login with Mastodon")
+
+    def validate_accept_license(self, field):
+        """Ensure the user agrees to the terms when logging in."""
+        if not field.data:
+            raise ValidationError(
+                "You must agree to the terms of service, license agreement, and privacy policy to log in."
+            )
 
 class LoginForm(FlaskForm):
     """User login form."""
@@ -87,7 +95,15 @@ class LoginForm(FlaskForm):
         render_kw={"autocomplete": "current-password"},
     )
     remember_me = BooleanField("Remember Me", default=True)
+    accept_license = BooleanField("I agree to the ", validators=[DataRequired()])
     submit = SubmitField("Sign In")
+
+    def validate_accept_license(self, field):
+        """Ensure the user agrees to the terms when logging in."""
+        if not field.data:
+            raise ValidationError(
+                "You must agree to the terms of service, license agreement, and privacy policy to log in."
+            )
 
 
 class LogoutForm(FlaskForm):

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -323,6 +323,7 @@
     <div id="game_IdHolder" data-game-id="{{ selected_game_id }}" class="d-none"></div>
     {% include 'modals/shout_board_modal.html' %}
     {% include 'modals/login_modal.html' %}
+    {% include 'modals/mastodon_login_modal.html' %}
     {% include 'modals/register_modal.html' %}
     {% include "modals/terms_modal.html" %}
     {% include "modals/privacy_modal.html" %}

--- a/app/templates/mastodon_login.html
+++ b/app/templates/mastodon_login.html
@@ -18,6 +18,21 @@
                     <small class="text-danger">{{ error }}</small>
                 {% endfor %}
             </div>
+            <div class="form-group mt-half">
+                <div class="d-inline-flex align-items-center gap-half">
+                    {{ form.accept_license(class="form-check-input") }}
+                    <label class="form-check-label" for="{{ form.accept_license.id }}">
+                        {{ form.accept_license.label.text }}
+                    </label>
+                </div>
+                {% for error in form.accept_license.errors %}
+                    <div class="text-danger mt-quarter">{{ error }}</div>
+                {% endfor %}
+                <div class="mt-half">
+                    <a href="javascript:void(0)" onclick="openModal('termsModal')">Terms of Service</a>, and
+                    <a href="javascript:void(0)" onclick="openModal('privacyModal')">Privacy Policy</a>
+                </div>
+            </div>
             <div class="form-group">
                 {{ form.submit(class="btn btn-primary") }}
             </div>

--- a/app/templates/modals/login_modal.html
+++ b/app/templates/modals/login_modal.html
@@ -50,6 +50,22 @@
           </label>
         </div>
 
+        <div class="form-group mt-half">
+          <div class="d-inline-flex align-items-center gap-half">
+            {{ login_form.accept_license(class="form-check-input") }}
+            <label class="form-check-label" for="{{ login_form.accept_license.id }}">
+              {{ login_form.accept_license.label.text }}
+            </label>
+          </div>
+          {% for err in login_form.accept_license.errors %}
+            <div class="text-danger mt-quarter">[{{ err }}]</div>
+          {% endfor %}
+          <div class="mt-half">
+            <a href="javascript:void(0)" onclick="openModal('termsModal')">Terms of Service</a>, and
+            <a href="javascript:void(0)" onclick="openModal('privacyModal')">Privacy Policy</a>
+          </div>
+        </div>
+
         <div class="form-group">
           <button type="submit" class="btn btn-primary" id="loginButton" disabled>
             Login
@@ -57,9 +73,9 @@
         </div>
 
         <div class="modal-footer">
-          <a href="{{ url_for('auth.mastodon_login') }}" class="btn btn-secondary">
+          <button type="button" class="btn btn-secondary" onclick="openModal('mastodonLoginModal')">
             Login with Mastodon
-          </a>
+          </button>
         </div>
       </form>
 

--- a/app/templates/modals/mastodon_login_modal.html
+++ b/app/templates/modals/mastodon_login_modal.html
@@ -1,0 +1,39 @@
+<!-- modals/mastodon_login_modal.html -->
+<div id="mastodonLoginModal" class="modal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h5 class="modal-title">Login with Mastodon</h5>
+      <button type="button" class="btn-close" aria-label="Close" onclick="closeModal('mastodonLoginModal')"></button>
+    </div>
+    <div class="modal-body">
+      <form id="mastodonLoginForm" method="post" action="{{ url_for('auth.mastodon_login') }}">
+        {{ mastodon_form.hidden_tag() }}
+        <div class="form-group">
+          {{ mastodon_form.instance.label }}
+          {{ mastodon_form.instance(class="form-control", placeholder="e.g., mastodon.social") }}
+          {% for err in mastodon_form.instance.errors %}
+            <span class="text-danger">[{{ err }}]</span>
+          {% endfor %}
+        </div>
+        <div class="form-group mt-half">
+          <div class="d-inline-flex align-items-center gap-half">
+            {{ mastodon_form.accept_license(class="form-check-input") }}
+            <label class="form-check-label" for="{{ mastodon_form.accept_license.id }}">
+              {{ mastodon_form.accept_license.label.text }}
+            </label>
+          </div>
+          {% for err in mastodon_form.accept_license.errors %}
+            <div class="text-danger mt-quarter">[{{ err }}]</div>
+          {% endfor %}
+          <div class="mt-half">
+            <a href="javascript:void(0)" onclick="openModal('termsModal')">Terms of Service</a>, and
+            <a href="javascript:void(0)" onclick="openModal('privacyModal')">Privacy Policy</a>
+          </div>
+        </div>
+        <div class="form-group">
+          {{ mastodon_form.submit(class="btn btn-primary") }}
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -96,7 +96,7 @@ def test_get_login_opens_modal(client):
 @pytest.mark.parametrize("headers,status_code,error,show_forgot", [
     ({}, 302, None, None),                                  
     ({"X-Requested-With": "XMLHttpRequest"}, 400,
-     "Please enter both email and password.", False),
+     "Please correct the errors in the login form.", False),
 ])
 def test_post_missing_credentials(client, headers, status_code, error, show_forgot):
     resp = client.post("/auth/login", data={}, headers=headers, follow_redirects=False)
@@ -109,7 +109,7 @@ def test_post_missing_credentials(client, headers, status_code, error, show_forg
 
 @pytest.mark.parametrize("ajax", [False, True])
 def test_post_invalid_email(client, ajax):
-    data = {"email": "doesnotexist@example.com", "password": "whatever"}
+    data = {"email": "doesnotexist@example.com", "password": "whatever", "accept_license": "y"}
     headers = {"X-Requested-With": "XMLHttpRequest"} if ajax else {}
     resp = client.post("/auth/login", data=data, headers=headers, follow_redirects=False)
     if ajax:
@@ -134,7 +134,7 @@ def test_post_invalid_email(client, ajax):
 def test_unverified_email_flow(client, user_unverified, app):
                                                             
     app.config["MAIL_SERVER"] = "smtp.test"
-    data = {"email": user_unverified.email, "password": "secret"}
+    data = {"email": user_unverified.email, "password": "secret", "accept_license": "y"}
                
     resp = client.post(
         "/auth/login",
@@ -149,7 +149,7 @@ def test_unverified_email_flow(client, user_unverified, app):
 
 @pytest.mark.parametrize("ajax", [False, True])
 def test_wrong_password(client, user_normal, ajax):
-    data = {"email": user_normal.email, "password": "wrongpwd"}
+    data = {"email": user_normal.email, "password": "wrongpwd", "accept_license": "y"}
     headers = {"X-Requested-With": "XMLHttpRequest"} if ajax else {}
     resp = client.post("/auth/login", data=data, headers=headers, follow_redirects=False)
     if ajax:
@@ -161,7 +161,7 @@ def test_wrong_password(client, user_normal, ajax):
 
 @pytest.mark.parametrize("ajax", [False, True])
 def test_successful_login_defaults_to_index(client, user_normal, ajax):
-    data = {"email": user_normal.email, "password": "secret", "remember_me": "y"}
+    data = {"email": user_normal.email, "password": "secret", "remember_me": "y", "accept_license": "y"}
     headers = {"X-Requested-With": "XMLHttpRequest"} if ajax else {}
     resp = client.post("/auth/login", data=data, headers=headers, follow_redirects=False)
     if ajax:
@@ -176,7 +176,7 @@ def test_successful_login_defaults_to_index(client, user_normal, ajax):
         assert resp.headers["Location"].startswith(expected)
 
 def test_successful_login_with_next_param(client, user_normal):
-    data = {"email": user_normal.email, "password": "secret", "remember_me": "y"}
+    data = {"email": user_normal.email, "password": "secret", "remember_me": "y", "accept_license": "y"}
     resp = client.post("/auth/login?next=/profile", data=data, follow_redirects=False)
                                           
     assert resp.status_code == 302

--- a/tests/test_auth_extra.py
+++ b/tests/test_auth_extra.py
@@ -76,20 +76,20 @@ def test_unverified_email_non_ajax(client, app, normal_user):
                              
     normal_user.email_verified = False
     db.session.commit()
-    data = {"email": normal_user.email, "password": "pw"}
+    data = {"email": normal_user.email, "password": "pw", "accept_license": "y"}
     resp = client.post("/auth/login", data=data, follow_redirects=False)
     assert resp.status_code == 302
                                                                              
     assert resp.headers["Location"].endswith(url_for("main.index", show_join_custom=0, _external=False))
 
 def test_successful_login_redirects_to_quest(client, normal_user):
-    data = {"email": normal_user.email, "password": "pw"}
+    data = {"email": normal_user.email, "password": "pw", "accept_license": "y"}
     resp = client.post("/auth/login?quest_id=123", data=data, follow_redirects=False)
     assert resp.status_code == 302
     assert resp.headers["Location"].endswith(url_for("main.index", show_join_custom=0, _external=False))
 
 def test_successful_login_redirects_admin_dashboard(client, admin_user):
-    data = {"email": admin_user.email, "password": "pw"}
+    data = {"email": admin_user.email, "password": "pw", "accept_license": "y"}
     resp = client.post("/auth/login", data=data, follow_redirects=False)
     assert resp.status_code == 302
     assert resp.headers["Location"].endswith(url_for("main.index", show_join_custom=0, _external=False))
@@ -98,7 +98,7 @@ def test_successful_login_redirects_admin_dashboard(client, admin_user):
 def test_login_exception_paths(client, normal_user, monkeypatch, ajax):
                                             
     monkeypatch.setattr("app.auth.login_user", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
-    data = {"email": normal_user.email, "password": "pw"}
+    data = {"email": normal_user.email, "password": "pw", "accept_license": "y"}
     headers = {"X-Requested-With": "XMLHttpRequest"} if ajax else {}
     resp = client.post("/auth/login", data=data, headers=headers, follow_redirects=False)
     assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- require users to agree to terms when signing in
- add support for terms on Mastodon login
- create Mastodon login modal and include it in the index page
- update login modal to link to Mastodon modal
- adjust tests for new terms requirement

## Testing
- `pytest tests/test_auth.py tests/test_auth_extra.py -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469226eb28832ba2ca89820b2ad0c2