### PR TITLE
Add optional comment to QR photo submission

### DIFF
--- a/app/quests.py
+++ b/app/quests.py
@@ -746,6 +746,7 @@ def submit_photo(quest_id):
 
         photo = request.files.get("photo")
         video = request.files.get("video")
+        comment = sanitize_html(request.form.get("verificationComment", ""))
 
                                                                              
                                                                            
@@ -790,7 +791,7 @@ def submit_photo(quest_id):
             user_id=current_user.id,
             image_url=image_url,
             video_url=video_url if video else None,
-            comment="",                                          
+            comment=comment,
             twitter_url=twitter_url,
             fb_url=fb_url,
             instagram_url=instagram_url,

--- a/app/templates/submit_photo.html
+++ b/app/templates/submit_photo.html
@@ -22,6 +22,8 @@
         <form id="submitPhotoForm" method="post" enctype="multipart/form-data" action="{{ url_for('quests.submit_photo', quest_id=quest.id) }}">
             {{ form.csrf_token }}
             <input type="file" name="photo" accept="image/*,video/*" capture="camera" required>
+            <label for="verificationComment" class="epic-label">Add a Comment (optional)</label>
+            <textarea id="verificationComment" name="verificationComment" class="epic-textarea" placeholder="Add an optional comment..."></textarea>
             <button type="submit">Submit</button>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- allow users to include a comment when submitting media via QR link
- persist the comment in the backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684692320f88832bbf7067f174235ead