### PR TITLE
Fix QR login redirect

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -319,10 +319,11 @@ def login():
 
                                                           
     if request.method == 'GET':
-                                     
+        show_login_flag = 0 if next_page else 1
+
         return redirect(
             url_for('main.index',
-                    show_login=1,
+                    show_login=show_login_flag,
                     show_join_custom=show_join,
                     game_id=game_id,
                     quest_id=quest_id,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -88,7 +88,7 @@ def test_get_login_opens_modal(client):
     assert parsed.path == expected_path
 
                                                          
-    assert params["show_login"] == ["1"]
+    assert params["show_login"] == ["0"]
     assert params["next"] == ["/foo/bar"]
 
 

--- a/tests/test_auth_extra.py
+++ b/tests/test_auth_extra.py
@@ -69,7 +69,7 @@ def test_login_redirect_if_authenticated_next_unsafe(client, normal_user):
     login_as(client, normal_user)
     resp = client.get("/auth/login?next=http://evil.com", follow_redirects=False)
     assert resp.status_code == 302
-    expected = url_for("main.index", show_login=1, next="http://evil.com", _external=False)
+    expected = url_for("main.index", show_login=0, next="http://evil.com", _external=False)
     assert resp.headers["Location"].endswith(expected)
 
 def test_unverified_email_non_ajax(client, app, normal_user):


### PR DESCRIPTION
## Summary
- redirect GET `/auth/login` with next param to homepage instead of login modal
- update tests for new behavior

## Testing
- `poetry run env PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469254054c832bb33065ddaa0138ce