### PR TITLE
Fix Quill initialization errors

### DIFF
--- a/frontend/modules/create_game.js
+++ b/frontend/modules/create_game.js
@@ -3,7 +3,11 @@ import { initQuill } from './quill_common.js';
         const editors = ['description', 'description2', 'details', 'awards', 'beyond'];
 
         editors.forEach(editorId => {
-            initQuill(`#${editorId}`, `#${editorId}-textarea`);
+            const editorEl = document.getElementById(editorId);
+            const hiddenEl = document.getElementById(`${editorId}-textarea`);
+            if (editorEl && hiddenEl) {
+                initQuill(editorEl, hiddenEl);
+            }
         });
     });
 

--- a/frontend/modules/edit_sponsors.js
+++ b/frontend/modules/edit_sponsors.js
@@ -1,5 +1,9 @@
 import { initQuill } from './quill_common.js';
 document.addEventListener('DOMContentLoaded', function() {
-    initQuill('#description', '#description-textarea');
+    const editorEl   = document.querySelector('#description');
+    const hiddenEl   = document.querySelector('#description-textarea');
+    if (editorEl && hiddenEl) {
+        initQuill(editorEl, hiddenEl);
+    }
 });
 

--- a/frontend/modules/manage_sponsors.js
+++ b/frontend/modules/manage_sponsors.js
@@ -1,10 +1,11 @@
 import { initQuill } from './quill_common.js';
     document.addEventListener('DOMContentLoaded', function() {
-        const descriptionEditor = initQuill('#description', '#description-textarea');
-        const descriptionTextarea = document.getElementById('description-textarea');
+        const editorEl   = document.querySelector('#description');
+        const hiddenEl   = document.querySelector('#description-textarea');
 
-        if (descriptionEditor && descriptionTextarea) {
-            descriptionEditor.root.innerHTML = descriptionTextarea.value;
+        if (editorEl && hiddenEl) {
+            const descriptionEditor = initQuill(editorEl, hiddenEl);
+            if (descriptionEditor) descriptionEditor.root.innerHTML = hiddenEl.value;
         }
     });
 

--- a/frontend/modules/shout_board_modal.js
+++ b/frontend/modules/shout_board_modal.js
@@ -10,9 +10,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   /* -------------------- initialise Quill once -------------------- */
   if (window.Quill) {
-    quill = initQuill('#shoutQuillEditor', '#shoutMessageInput', {
-      placeholder: 'Write an announcement…'
-    });
+    const editorEl = document.querySelector('#shoutQuillEditor');
+    const hiddenEl = document.querySelector('#shoutMessageInput');
+    if (editorEl && hiddenEl) {
+      quill = initQuill(editorEl, hiddenEl, {
+        placeholder: 'Write an announcement…'
+      });
+    }
   } else {
     console.error('Quill library not found  shoutboard editor will not work.');
   }


### PR DESCRIPTION
## Summary
- avoid console errors when Quill editors are not present

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6846a67b669c832bace3e285607975b0