### PR TITLE
Fix Quill initialization checks

### DIFF
--- a/frontend/modules/add_quest.js
+++ b/frontend/modules/add_quest.js
@@ -5,8 +5,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const descriptionEl = document.querySelector('#description-editor');
   const tipsEl        = document.querySelector('#tips-editor');
 
-  const quillDescription = descriptionEl ? initQuill(descriptionEl) : null;
-  const quillTips        = tipsEl ? initQuill(tipsEl) : null;
+  const quillDescription = (descriptionEl && window.Quill) ? initQuill(descriptionEl) : null;
+  const quillTips        = (tipsEl && window.Quill) ? initQuill(tipsEl) : null;
+  if ((!window.Quill) && (descriptionEl || tipsEl)) {
+    console.error('Quill library not found  quest editor will not work.');
+  }
 
   const questForm = document.getElementById('quest-form');
   if (questForm && quillDescription && quillTips) {

--- a/frontend/modules/create_game.js
+++ b/frontend/modules/create_game.js
@@ -6,7 +6,11 @@ import { initQuill } from './quill_common.js';
             const editorEl = document.getElementById(editorId);
             const hiddenEl = document.getElementById(`${editorId}-textarea`);
             if (editorEl && hiddenEl) {
-                initQuill(editorEl, hiddenEl);
+                if (window.Quill) {
+                    initQuill(editorEl, hiddenEl);
+                } else {
+                    console.error('Quill library not found  game editor will not work.');
+                }
             }
         });
     });

--- a/frontend/modules/edit_sponsors.js
+++ b/frontend/modules/edit_sponsors.js
@@ -3,7 +3,11 @@ document.addEventListener('DOMContentLoaded', function() {
     const editorEl   = document.querySelector('#description');
     const hiddenEl   = document.querySelector('#description-textarea');
     if (editorEl && hiddenEl) {
-        initQuill(editorEl, hiddenEl);
+        if (window.Quill) {
+            initQuill(editorEl, hiddenEl);
+        } else {
+            console.error('Quill library not found  sponsor editor will not work.');
+        }
     }
 });
 

--- a/frontend/modules/index_management.js
+++ b/frontend/modules/index_management.js
@@ -124,11 +124,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const quillEditorContainer = document.getElementById('quill-editor');
   if (quillEditorContainer) {
-    const quill = initQuill('#quill-editor', '#message-input', {
-      placeholder: 'Write a message...',
-      modules: { toolbar: [[{ header: [1, 2, false] }], ['bold', 'italic', 'underline'], ['link'], [{ list: 'ordered' }, { list: 'bullet' }], ['clean']] }
-    });
-    document.querySelector('form').onsubmit = () => true;
+    if (window.Quill) {
+      const quill = initQuill(quillEditorContainer, '#message-input', {
+        placeholder: 'Write a message...',
+        modules: {
+          toolbar: [
+            [{ header: [1, 2, false] }],
+            ['bold', 'italic', 'underline'],
+            ['link'],
+            [{ list: 'ordered' }, { list: 'bullet' }],
+            ['clean']
+          ]
+        }
+      });
+      document.querySelector('form').onsubmit = () => true;
+    } else {
+      console.error('Quill library not found  message editor will not work.');
+    }
   }
 
   document.querySelectorAll('.activity-message').forEach(el => {

--- a/frontend/modules/manage_quests.js
+++ b/frontend/modules/manage_quests.js
@@ -216,10 +216,13 @@ import { initQuill } from './quill_common.js';
             cell.innerHTML = '';
             cell.appendChild(editor);
             
-            const quill = initQuill(editor);
-
-            quill.root.innerHTML = currentValue;
-            cell.__quill = quill;
+            if (window.Quill) {
+                const quill = initQuill(editor);
+                quill.root.innerHTML = currentValue;
+                cell.__quill = quill;
+            } else {
+                console.error('Quill library not found  quest editing will not work.');
+            }
         }
     }
 
@@ -438,14 +441,18 @@ import { initQuill } from './quill_common.js';
             const descriptionEditorContainer = card.querySelector('.quill-editor-container[data-name="description"]');
             const tipsEditorContainer = card.querySelector('.quill-editor-container[data-name="tips"]');
 
-            if (descriptionEditorContainer && !descriptionEditorContainer.__quill) {
-                const quillDescription = initQuill(descriptionEditorContainer);
-                descriptionEditorContainer.__quill = quillDescription;
-            }
+            if (window.Quill) {
+                if (descriptionEditorContainer && !descriptionEditorContainer.__quill) {
+                    const quillDescription = initQuill(descriptionEditorContainer);
+                    descriptionEditorContainer.__quill = quillDescription;
+                }
 
-            if (tipsEditorContainer && !tipsEditorContainer.__quill) {
-                const quillTips = initQuill(tipsEditorContainer);
-                tipsEditorContainer.__quill = quillTips;
+                if (tipsEditorContainer && !tipsEditorContainer.__quill) {
+                    const quillTips = initQuill(tipsEditorContainer);
+                    tipsEditorContainer.__quill = quillTips;
+                }
+            } else {
+                console.error('Quill library not found  quest editing will not work.');
             }
         }
     }

--- a/frontend/modules/manage_sponsors.js
+++ b/frontend/modules/manage_sponsors.js
@@ -4,8 +4,12 @@ import { initQuill } from './quill_common.js';
         const hiddenEl   = document.querySelector('#description-textarea');
 
         if (editorEl && hiddenEl) {
-            const descriptionEditor = initQuill(editorEl, hiddenEl);
-            if (descriptionEditor) descriptionEditor.root.innerHTML = hiddenEl.value;
+            if (window.Quill) {
+                const descriptionEditor = initQuill(editorEl, hiddenEl);
+                if (descriptionEditor) descriptionEditor.root.innerHTML = hiddenEl.value;
+            } else {
+                console.error('Quill library not found  sponsor editor will not work.');
+            }
         }
     });
 


### PR DESCRIPTION
## Summary
- guard Quill initialization in various modules

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846b30270ac832bae4027721ab71c25