### PR TITLE
Remove license checkbox from standard login

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -95,15 +95,7 @@ class LoginForm(FlaskForm):
         render_kw={"autocomplete": "current-password"},
     )
     remember_me = BooleanField("Remember Me", default=True)
-    accept_license = BooleanField("I agree to the ", validators=[DataRequired()])
     submit = SubmitField("Sign In")
-
-    def validate_accept_license(self, field):
-        """Ensure the user agrees to the terms when logging in."""
-        if not field.data:
-            raise ValidationError(
-                "You must agree to the terms of service, license agreement, and privacy policy to log in."
-            )
 
 
 class LogoutForm(FlaskForm):

--- a/app/templates/modals/login_modal.html
+++ b/app/templates/modals/login_modal.html
@@ -50,21 +50,6 @@
           </label>
         </div>
 
-        <div class="form-group mt-half">
-          <div class="d-inline-flex align-items-center gap-half">
-            {{ login_form.accept_license(class="form-check-input") }}
-            <label class="form-check-label" for="{{ login_form.accept_license.id }}">
-              {{ login_form.accept_license.label.text }}
-            </label>
-          </div>
-          {% for err in login_form.accept_license.errors %}
-            <div class="text-danger mt-quarter">[{{ err }}]</div>
-          {% endfor %}
-          <div class="mt-half">
-            <a href="javascript:void(0)" onclick="openModal('termsModal')">Terms of Service</a>, and
-            <a href="javascript:void(0)" onclick="openModal('privacyModal')">Privacy Policy</a>
-          </div>
-        </div>
 
         <div class="form-group">
           <button type="submit" class="btn btn-primary" id="loginButton" disabled>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -109,7 +109,7 @@ def test_post_missing_credentials(client, headers, status_code, error, show_forg
 
 @pytest.mark.parametrize("ajax", [False, True])
 def test_post_invalid_email(client, ajax):
-    data = {"email": "doesnotexist@example.com", "password": "whatever", "accept_license": "y"}
+    data = {"email": "doesnotexist@example.com", "password": "whatever"}
     headers = {"X-Requested-With": "XMLHttpRequest"} if ajax else {}
     resp = client.post("/auth/login", data=data, headers=headers, follow_redirects=False)
     if ajax:
@@ -134,7 +134,7 @@ def test_post_invalid_email(client, ajax):
 def test_unverified_email_flow(client, user_unverified, app):
                                                             
     app.config["MAIL_SERVER"] = "smtp.test"
-    data = {"email": user_unverified.email, "password": "secret", "accept_license": "y"}
+    data = {"email": user_unverified.email, "password": "secret"}
                
     resp = client.post(
         "/auth/login",
@@ -149,7 +149,7 @@ def test_unverified_email_flow(client, user_unverified, app):
 
 @pytest.mark.parametrize("ajax", [False, True])
 def test_wrong_password(client, user_normal, ajax):
-    data = {"email": user_normal.email, "password": "wrongpwd", "accept_license": "y"}
+    data = {"email": user_normal.email, "password": "wrongpwd"}
     headers = {"X-Requested-With": "XMLHttpRequest"} if ajax else {}
     resp = client.post("/auth/login", data=data, headers=headers, follow_redirects=False)
     if ajax:
@@ -161,7 +161,7 @@ def test_wrong_password(client, user_normal, ajax):
 
 @pytest.mark.parametrize("ajax", [False, True])
 def test_successful_login_defaults_to_index(client, user_normal, ajax):
-    data = {"email": user_normal.email, "password": "secret", "remember_me": "y", "accept_license": "y"}
+    data = {"email": user_normal.email, "password": "secret", "remember_me": "y"}
     headers = {"X-Requested-With": "XMLHttpRequest"} if ajax else {}
     resp = client.post("/auth/login", data=data, headers=headers, follow_redirects=False)
     if ajax:
@@ -176,7 +176,7 @@ def test_successful_login_defaults_to_index(client, user_normal, ajax):
         assert resp.headers["Location"].startswith(expected)
 
 def test_successful_login_with_next_param(client, user_normal):
-    data = {"email": user_normal.email, "password": "secret", "remember_me": "y", "accept_license": "y"}
+    data = {"email": user_normal.email, "password": "secret", "remember_me": "y"}
     resp = client.post("/auth/login?next=/profile", data=data, follow_redirects=False)
                                           
     assert resp.status_code == 302

--- a/tests/test_auth_extra.py
+++ b/tests/test_auth_extra.py
@@ -76,20 +76,20 @@ def test_unverified_email_non_ajax(client, app, normal_user):
                              
     normal_user.email_verified = False
     db.session.commit()
-    data = {"email": normal_user.email, "password": "pw", "accept_license": "y"}
+    data = {"email": normal_user.email, "password": "pw"}
     resp = client.post("/auth/login", data=data, follow_redirects=False)
     assert resp.status_code == 302
                                                                              
     assert resp.headers["Location"].endswith(url_for("main.index", show_join_custom=0, _external=False))
 
 def test_successful_login_redirects_to_quest(client, normal_user):
-    data = {"email": normal_user.email, "password": "pw", "accept_license": "y"}
+    data = {"email": normal_user.email, "password": "pw"}
     resp = client.post("/auth/login?quest_id=123", data=data, follow_redirects=False)
     assert resp.status_code == 302
     assert resp.headers["Location"].endswith(url_for("main.index", show_join_custom=0, _external=False))
 
 def test_successful_login_redirects_admin_dashboard(client, admin_user):
-    data = {"email": admin_user.email, "password": "pw", "accept_license": "y"}
+    data = {"email": admin_user.email, "password": "pw"}
     resp = client.post("/auth/login", data=data, follow_redirects=False)
     assert resp.status_code == 302
     assert resp.headers["Location"].endswith(url_for("main.index", show_join_custom=0, _external=False))
@@ -98,7 +98,7 @@ def test_successful_login_redirects_admin_dashboard(client, admin_user):
 def test_login_exception_paths(client, normal_user, monkeypatch, ajax):
                                             
     monkeypatch.setattr("app.auth.login_user", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
-    data = {"email": normal_user.email, "password": "pw", "accept_license": "y"}
+    data = {"email": normal_user.email, "password": "pw"}
     headers = {"X-Requested-With": "XMLHttpRequest"} if ajax else {}
     resp = client.post("/auth/login", data=data, headers=headers, follow_redirects=False)
     assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- remove `accept_license` field from `LoginForm`
- update login modal template to drop the checkbox
- update login related tests

## Testing
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6847483cc410832b87086aea0c0c5e22