### PR TITLE
Fix modal function exports

### DIFF
--- a/frontend/modules/badge_modal.js
+++ b/frontend/modules/badge_modal.js
@@ -129,7 +129,7 @@ function populateBadgeModal(badge, requiredCount, currentUserCompletions, taskLi
  * Open the badge modal and populate it with data.
  * @param {HTMLElement} element - The badge element that was clicked.
  */
-async function openBadgeModal(element) {
+export async function openBadgeModal(element) {
   const badgeId = element.getAttribute('data-badge-id');
   const taskNames = element.getAttribute('data-task-name');
   const taskIdsAttr = element.getAttribute('data-task-id');

--- a/frontend/modules/delete_game_modal.js
+++ b/frontend/modules/delete_game_modal.js
@@ -1,6 +1,6 @@
 let deleteInterval;
 
-function openDeleteGameModal(gameId) {
+export function openDeleteGameModal(gameId) {
   const modal = document.getElementById('deleteGameModal');
   const form  = document.getElementById('deleteGameForm');
   const input = document.getElementById('deleteGameConfirmInput');
@@ -51,4 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
     confirmBtn.disabled = true;
   });
 });
+
+// Expose globally for inline handlers
+window.openDeleteGameModal = openDeleteGameModal;
 

--- a/frontend/modules/modal_common.js
+++ b/frontend/modules/modal_common.js
@@ -1,7 +1,7 @@
 let topZIndex = 3000;
 let scrollY = 0;
 
-function openModal(modalId) {
+export function openModal(modalId) {
   const modal = document.getElementById(modalId);
   if (!modal) {
     console.error(`Modal ${modalId} not found`);
@@ -106,12 +106,12 @@ function updateModalHiddenFields(modalId, options) {
     }
 }
 
-function openLoginModalWithOptions(options) {
+export function openLoginModalWithOptions(options) {
     updateModalHiddenFields('loginModal', options);
     openModal('loginModal');
 }
 
-function openRegisterModalWithOptions(options = {}) {
+export function openRegisterModalWithOptions(options = {}) {
     // 1) rewrite the <form> action so a full‐page POST carries the same ?game_id…etc
     const form = document.getElementById('registerForm');
     const base = form.getAttribute('action').split('?')[0];
@@ -136,7 +136,7 @@ function openRegisterModalWithOptions(options = {}) {
   }
 
 
-function openLoginModalWithGame({ gameId, questId = '' }) {
+export function openLoginModalWithGame({ gameId, questId = '' }) {
     const loginForm       = document.getElementById('loginForm');
     const loginGameId     = document.getElementById('loginGameId');
     const loginQuestId    = document.getElementById('loginQuestId');
@@ -202,7 +202,7 @@ function openLoginModalWithGame({ gameId, questId = '' }) {
   }
 
 // Call this to show the Forgot Password modal and pre-fill its email
-function openForgotPasswordModal() {
+export function openForgotPasswordModal() {
     const loginEmailVal   = document.getElementById('loginEmail')?.value || '';
     const forgotEmailInput = document.getElementById('forgotEmail');
     if (forgotEmailInput) {
@@ -219,7 +219,7 @@ function openForgotPasswordModal() {
 }
 
 // Opens the Reset-Password modal, injecting the token from the URL
-function openResetPasswordModal(token) {
+export function openResetPasswordModal(token) {
     const form    = document.getElementById('resetForm');
     const input   = document.getElementById('resetToken');
     // Read the base action URL that Flask already rendered

--- a/frontend/modules/quest_detail_modal.js
+++ b/frontend/modules/quest_detail_modal.js
@@ -16,7 +16,7 @@ window.PLACEHOLDER_IMAGE = PLACEHOLDER_IMAGE;
 /* ------------------------------------------------------------------ */
 /*  OPEN QUEST DETAIL MODAL                                           */
 /* ------------------------------------------------------------------ */
-function openQuestDetailModal(questId) {
+export function openQuestDetailModal(questId) {
   resetModalContent();
 
   fetch(`/quests/detail/${questId}/user_completion`, { credentials: 'same-origin' })


### PR DESCRIPTION
## Summary
- export open modal helpers for ES module use
- expose `openDeleteGameModal` globally for inline usage

## Testing
- `npm run build` *(fails: vite not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684755955fec832bb07fae731db34bbd