### PR TITLE
Fix imports for Vite modules

### DIFF
--- a/frontend/modules/game_info_modal.js
+++ b/frontend/modules/game_info_modal.js
@@ -1,3 +1,5 @@
+import { fetchAndShowModal } from './modal_common.js';
+
 function showGameInfoModal(gameId) {
     const url = '/games/game-info/' + gameId + '?modal=1';
     fetchAndShowModal(url, 'gameInfoModal');

--- a/frontend/modules/modal_common.js
+++ b/frontend/modules/modal_common.js
@@ -357,7 +357,7 @@ document.addEventListener('DOMContentLoaded', () => {
  * Generic loader: fetch a chunk of HTML, inject its first node,
  * then `openModal(modalId)`.
  */
-async function fetchAndShowModal(url, modalId) {
+export async function fetchAndShowModal(url, modalId) {
   try {
     const res = await fetch(url, { credentials: 'same-origin' });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);


### PR DESCRIPTION
## Summary
- export `fetchAndShowModal` from modal_common
- import `fetchAndShowModal` in game_info_modal

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68476423f0b4832baa280eb29f8d6f74