### PR TITLE
Expose leaderboard modal

### DIFF
--- a/frontend/modules/index_management.js
+++ b/frontend/modules/index_management.js
@@ -1,5 +1,6 @@
 import { initQuill } from './quill_common.js';
 import { showLoadingModal, hideLoadingModal } from './loading_modal.js';
+import { showLeaderboardModal } from './leaderboard_modal.js';
 const refreshCSRFToken = async () => {
   try {
     const res  = await fetch('/refresh-csrf');

--- a/frontend/modules/leaderboard_modal.js
+++ b/frontend/modules/leaderboard_modal.js
@@ -4,7 +4,7 @@ let leaderboardData = null;
 let leaderboardMetric = 'points';
 let leaderboardBody;
 
-function showLeaderboardModal(selectedGameId) {
+export function showLeaderboardModal(selectedGameId) {
     const leaderboardContent = document.getElementById('leaderboardModalContent');
     if (!leaderboardContent) {
         console.error('Leaderboard modal content element not found. Cannot proceed with displaying leaderboard.');
@@ -216,4 +216,7 @@ function updateLeaderboardRows() {
         leaderboardBody.appendChild(row);
     });
 }
+
+// Make available globally for inline scripts
+window.showLeaderboardModal = showLeaderboardModal;
 


### PR DESCRIPTION
## Summary
- export `showLeaderboardModal` from `leaderboard_modal.js`
- attach `showLeaderboardModal` to `window` for global use
- import it in `index_management.js`

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68476981e998832b922a705e54ae8983