### PR TITLE
Fix leaderboard modal import

### DIFF
--- a/frontend/layout.js
+++ b/frontend/layout.js
@@ -1,3 +1,5 @@
+import { showLeaderboardModal } from './modules/leaderboard_modal.js';
+
 export function initLayout() {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker
@@ -104,11 +106,7 @@ export function initLayout() {
     leaderboardLink.addEventListener('click', (e) => {
       e.preventDefault();
       const gameId = leaderboardLink.getAttribute('data-game-id') || 0;
-      if (typeof window.showLeaderboardModal === 'function') {
-        window.showLeaderboardModal(gameId);
-      } else {
-        console.error('showLeaderboardModal not defined');
-      }
+      showLeaderboardModal(gameId);
     });
   }
 


### PR DESCRIPTION
## Summary
- import `showLeaderboardModal` in the layout script instead of relying on a global
- simplify the leaderboard click handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68476b15a4f0832b9aca0ce88bedf365