### PR TITLE
Add ffmpeg fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This project relies on a variety of open source libraries. The badges below link
 - Python 3.11+
 - PostgreSQL
 - git
-- ffmpeg (for video processing)
+- ffmpeg (optional, for video compression)
 - Poetry (for dependency management)
 - NGINX with Certbot
 - UFW firewall
@@ -191,7 +191,7 @@ This project relies on a variety of open source libraries. The badges below link
 14. Configure
     - Copy `config.toml.example` to `config.toml` and adjust the variables accordingly.
     - Copy `gunicorn.conf.py.example` to `gunicorn.conf.py` and adjust the variables accordingly.
-    - Ensure the `ffmpeg` binary is installed and accessible or set `FFMPEG_PATH` in `config.toml`.
+    - If you have `ffmpeg` installed, ensure it is accessible or set `FFMPEG_PATH` in `config.toml`. Without `ffmpeg` videos are stored unmodified.
 
 15. Run the server in debug
 ```sudo -u APPUSER /home/APPUSER/.local/bin/poetry run flask   --app wsgi:app   run   --host=127.0.0.1   --port=5000```

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -95,7 +95,7 @@ Ensure you have the following installed:
 - Python 3.x
 - PostgreSQL
 - Virtualenv
-- ffmpeg
+- ffmpeg (optional for video compression)
 
 ### Installation
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,23 @@ def test_save_submission_video_invalid(app, tmp_path):
         save_submission_video(file)
 
 
+def test_save_submission_video_no_ffmpeg(app, monkeypatch):
+    """Video saving should bypass conversion if ffmpeg is unavailable."""
+    from io import BytesIO
+    from werkzeug.datastructures import FileStorage
+    from app.utils import save_submission_video
+    import shutil
+
+    video_data = BytesIO(b"0" * 100)
+    file = FileStorage(stream=video_data, filename="small.mp4", content_type="video/mp4")
+
+    app.config["FFMPEG_PATH"] = "/nonexistent/ffmpeg"
+    monkeypatch.setattr(shutil, "which", lambda x: None)
+
+    path = save_submission_video(file)
+    assert path.endswith(".mp4")
+
+
 def test_save_submission_image_invalid_extension(app, tmp_path):
     """Uploading a non-image file should raise a ValueError."""
     from io import BytesIO


### PR DESCRIPTION
## Summary
- bypass ffmpeg if it isn't available
- document ffmpeg as optional in developer guides
- test fallback behavior

## Testing
- `pytest tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6847721a9dbc832b98774a1e30245777