### PR TITLE
Fix missing profile handlers

### DIFF
--- a/frontend/modules/user_profile_modal.js
+++ b/frontend/modules/user_profile_modal.js
@@ -510,4 +510,10 @@ function deleteAccount() {
 }
 // Expose globally for inline handlers
 window.showUserProfileModal = showUserProfileModal;
+window.toggleProfileEditMode = toggleProfileEditMode;
+window.cancelProfileEdit = cancelProfileEdit;
+window.saveProfile = saveProfile;
+window.saveBike = saveBike;
+window.deleteSubmission = deleteSubmission;
+window.deleteAccount = deleteAccount;
 


### PR DESCRIPTION
## Summary
- expose profile editing functions on window so inline onclick handlers work

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6847789a801c832b8ff4681844fafbc4