### PR TITLE
Fix delete modal when DOM missing

### DIFF
--- a/frontend/modules/delete_game_modal.js
+++ b/frontend/modules/delete_game_modal.js
@@ -27,6 +27,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const undoBtn = document.getElementById('deleteGameUndo');
   const form = document.getElementById('deleteGameForm');
 
+  // If any of the required elements are missing, skip attaching
+  if (!input || !confirmBtn || !countdown || !timerSpan || !undoBtn || !form) {
+    return;
+  }
+
   input.addEventListener('input', () => {
     confirmBtn.disabled = input.value.trim().toLowerCase() !== 'delete';
   });


### PR DESCRIPTION
## Summary
- ignore delete modal listeners if elements aren't present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68477ebd2678832baf89e6a1a4577886