### PR TITLE
Add PWA quest shortcuts

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -34,7 +34,7 @@
   <!-- Browser Compatibility Meta Tags -->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="manifest" href="{{ url_for('main.manifest') }}">
+  <link rel="manifest" href="{{ url_for('main.manifest', game_id=selected_game_id) }}">
   <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <link rel="apple-touch-icon" href="{{ url_for('static', filename='icons/apple-touch-icon-180x180.png') }}">
 

--- a/frontend/modules/modal_common.js
+++ b/frontend/modules/modal_common.js
@@ -273,11 +273,23 @@ document.addEventListener('DOMContentLoaded', () => {
     const params     = new URLSearchParams(window.location.search);
     const showJoin   = params.get('show_join_custom') === '1';
     const hasGameId  = params.has('game_id');
-  
+
     if (showJoin && !hasGameId) {
       openModal('joinCustomGameModal');
     }
   });
+
+// ────────────────────────────────────────────────────────────
+// Auto-open quest detail modal if URL contains quest_shortcut
+// ────────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', () => {
+  const params   = new URLSearchParams(window.location.search);
+  const questId  = params.get('quest_shortcut');
+  if (questId) {
+    openQuestDetailModal(questId);
+    history.replaceState(null, '', window.location.pathname);
+  }
+});
   
 // ─────────────────────────────────────────────────────────────────
 // Auto‐open the login modal for QR links like:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -33,3 +33,36 @@ def test_launch_handler_is_object(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data.get('launch_handler'), dict)
+
+
+def test_manifest_shortcuts(client, app):
+    from app.models import db, Game, Quest, User
+    from datetime import datetime, timezone, timedelta
+
+    with app.app_context():
+        user = User(username='u', email='u@example.com', license_agreed=True)
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+
+        game = Game(
+            title='G',
+            start_date=datetime.now(timezone.utc) - timedelta(days=1),
+            end_date=datetime.now(timezone.utc) + timedelta(days=1),
+            admin_id=user.id,
+        )
+        game.admins.append(user)
+        db.session.add(game)
+        db.session.commit()
+
+        quest = Quest(title='Q', game=game)
+        db.session.add(quest)
+        db.session.commit()
+
+        resp = client.get(f'/manifest.json?game_id={game.id}')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert any(
+            sc.get('url', '').endswith(f'quest_shortcut={quest.id}')
+            for sc in data.get('shortcuts', [])
+        )


### PR DESCRIPTION
## Summary
- allow game-specific manifest with dynamic quest shortcuts
- open quest modals when arriving with `quest_shortcut` param
- pass current game id to manifest link
- test manifest dynamic shortcuts

## Testing
- `pytest tests/test_manifest.py::test_manifest_shortcuts -q` *(fails: ModuleNotFoundError: No module named 'html_sanitizer')*

------
https://chatgpt.com/codex/tasks/task_e_684781d1aa58832b9739a831fdf28beb