### PR TITLE
Fix leaderboard modal imports

### DIFF
--- a/frontend/modules/index_management.js
+++ b/frontend/modules/index_management.js
@@ -1,5 +1,6 @@
 import { showLoadingModal, hideLoadingModal } from './loading_modal.js';
 import { showLeaderboardModal } from './leaderboard_modal.js';
+import { closeModal } from './modal_common.js';
 const refreshCSRFToken = async () => {
   try {
     const res  = await fetch('/refresh-csrf');

--- a/frontend/modules/modal_common.js
+++ b/frontend/modules/modal_common.js
@@ -29,7 +29,7 @@ export function openModal(modalId) {
   document.body.classList.add('body-no-scroll');
 }
 
-function closeModal(modalId) {
+export function closeModal(modalId) {
   const modal = document.getElementById(modalId);
   if (!modal) return;
 

--- a/frontend/modules/submission_detail_modal.js
+++ b/frontend/modules/submission_detail_modal.js
@@ -1,5 +1,4 @@
-import { openModal } from './modal_common.js';
-import { resetModalContent } from './modal_common.js';
+import { openModal, closeModal, resetModalContent } from './modal_common.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 


### PR DESCRIPTION
## Summary
- export `closeModal` from `modal_common.js`
- import `closeModal` where needed

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684783a7462c832b8f1eb473ce3331da