### PR TITLE
Fix missing form error in submit_photo module

### DIFF
--- a/frontend/modules/submit_photo.js
+++ b/frontend/modules/submit_photo.js
@@ -3,6 +3,12 @@ import { showLoadingModal, hideLoadingModal } from './loading_modal.js';
 
 document.addEventListener('DOMContentLoaded', function () {
     const submitPhotoForm = document.getElementById('submitPhotoForm');
+
+    if (!submitPhotoForm) {
+        console.error('submitPhotoForm element not found on page.');
+        return;
+    }
+
     let isSubmitting = false;
 
     // Handle form submission


### PR DESCRIPTION
## Summary
- check for the submit form before attaching event handlers

## Testing
- `poetry run python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68478ce0a9b8832b99f4d71e0345acd5