### PR TITLE
Fix null DOM references

### DIFF
--- a/frontend/modules/badge_modal.js
+++ b/frontend/modules/badge_modal.js
@@ -95,6 +95,11 @@ function populateBadgeModal(badge, requiredCount, currentUserCompletions, taskLi
   const modalImage = document.getElementById('badgeModalImage');
   const modalText  = document.getElementById('badgeModalText');
 
+  if (!modalTitle || !modalImage || !modalText) {
+    console.error('Badge modal elements missing');
+    return;
+  }
+
   modalTitle.textContent = badge.name;
   modalImage.src = validateImageUrl(badge.image) || PLACEHOLDER_IMAGE;
 

--- a/frontend/modules/delete_game_modal.js
+++ b/frontend/modules/delete_game_modal.js
@@ -10,6 +10,11 @@ export function openDeleteGameModal(gameId) {
   const timerSpan = document.getElementById('deleteGameTimer');
   const confirmBtn = document.getElementById('deleteGameConfirmBtn');
 
+  if (!modal || !form || !input || !countdown || !timerSpan || !confirmBtn) {
+    console.warn('Delete game modal elements missing');
+    return;
+  }
+
   modal.dataset.gameId = gameId;
   form.action = `/games/delete_game/${gameId}`;
   input.value = '';

--- a/frontend/modules/quest_detail_modal.js
+++ b/frontend/modules/quest_detail_modal.js
@@ -186,6 +186,10 @@ function populateQuestDetails(quest, userCompletionCount, canVerify, questId, ne
 
 function ensureDynamicElementsExistAndPopulate(quest, userCompletionCount, nextEligibleTime, canVerify) {
     const parentElement = document.querySelector('.user-quest-data');
+    if (!parentElement) {
+        console.error('Parent element .user-quest-data not found');
+        return;
+    }
 
     const dynamicElements = [
         { id: 'modalQuestCompletions', value: `${userCompletionCount || 0}` },
@@ -230,6 +234,10 @@ function formatTimeDiff(ms) {
 
 function manageVerificationSection(questId, canVerify, verificationType, nextEligibleTime) {
     const userQuestData = document.querySelector('.user-quest-data');
+    if (!userQuestData) {
+        console.error('Parent element .user-quest-data not found');
+        return;
+    }
     userQuestData.innerHTML = '';
 
     if (canVerify) {
@@ -569,11 +577,14 @@ function isValidImageUrl(url) {
 
 function distributeImages(images) {
     const board = document.getElementById('submissionBoard');
+    if (!board) {
+        console.error('submissionBoard element not found');
+        return;
+    }
     board.innerHTML = '';
 
     const rawFallbackRaw =
-        document.getElementById('questDetailModal')
-                .getAttribute('data-placeholder-url') ||
+        document.getElementById('questDetailModal')?.getAttribute('data-placeholder-url') ||
         PLACEHOLDER_IMAGE;
     const rawFallback = isValidImageUrl(rawFallbackRaw) ? rawFallbackRaw : PLACEHOLDER_IMAGE;
 

--- a/frontend/modules/user_profile_modal.js
+++ b/frontend/modules/user_profile_modal.js
@@ -371,6 +371,10 @@ document.querySelectorAll('.needs-validation').forEach(form => {
 function toggleProfileEditMode() {
   const viewDiv = document.getElementById('profileViewMode');
   const editDiv = document.getElementById('profileEditMode');
+  if (!viewDiv || !editDiv) {
+    console.error('Profile edit mode elements missing');
+    return;
+  }
   viewDiv.classList.toggle('d-none');
   editDiv.classList.toggle('d-none');
 }
@@ -381,6 +385,10 @@ function cancelProfileEdit(userId) {
 
 function saveProfile(userId) {
   const form = document.getElementById('editProfileForm');
+  if (!form) {
+    console.error('Edit profile form not found');
+    return;
+  }
   const formData = new FormData(form);
   const profilePictureInput = document.getElementById('profilePictureInput');
   if (profilePictureInput.files.length > 0) {
@@ -426,6 +434,10 @@ function saveProfile(userId) {
 
 function saveBike(userId) {
   const form = document.getElementById('editBikeForm');
+  if (!form) {
+    console.error('Edit bike form not found');
+    return;
+  }
   const formData = new FormData(form);
   const bikePictureInput = document.getElementById('bikePicture');
   if (bikePictureInput.files.length > 0) {


### PR DESCRIPTION
## Summary
- add guard clauses for missing badge modal elements
- check all delete game modal elements exist before use
- validate quest detail modal parent nodes and board
- validate profile modal edit forms and mode toggles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6847910f65b0832ba11b2c635c3a6b23