### PR TITLE
Migrate Sass code to @use syntax

### DIFF
--- a/app/static/scss/components/_badge-bar.scss
+++ b/app/static/scss/components/_badge-bar.scss
@@ -1,5 +1,5 @@
-@import '../abstracts/functions';
-@import '../abstracts/mixins';
+@use '../abstracts/functions' as *;
+@use '../abstracts/mixins' as *;
 
 .badge-bar-container {
   background-color: #f1ffee;

--- a/app/static/scss/components/_badges.scss
+++ b/app/static/scss/components/_badges.scss
@@ -1,3 +1,4 @@
+@use "../abstracts/variables" as *;
 .badge {
     display: inline-block;
     padding: 0.25em 0.5em;

--- a/app/static/scss/components/_dropdown.scss
+++ b/app/static/scss/components/_dropdown.scss
@@ -1,5 +1,6 @@
-@import '../abstracts/functions';
-@import '../abstracts/mixins';
+@use '../abstracts/functions' as *;
+@use '../abstracts/mixins' as *;
+@use 'sass:color';
 
 // Dropdown variables
 $dropdown-bg:        #e2e8db;
@@ -70,7 +71,7 @@ $dropdown-item-max-width: pxToRem(290); // Keeps items inside bounds
     transition: background 0.18s, color 0.18s;
     &:hover, &:focus-visible, &[aria-expanded="true"] {
       background: $dropdown-hover-bg;
-      color: darken($dropdown-color, 14%);
+      color: color.adjust($dropdown-color, $lightness: -14%);
       outline: none;
     }
     .dropdown-toggle-icon {
@@ -101,7 +102,7 @@ $dropdown-item-max-width: pxToRem(290); // Keeps items inside bounds
     &:hover,
     &:focus {
       background: $dropdown-hover-bg;
-      color: darken($dropdown-color, 8%);
+      color: color.adjust($dropdown-color, $lightness: -8%);
       outline: none;
     }
     &.fw-bold    { font-weight: bold; }
@@ -119,7 +120,7 @@ $dropdown-item-max-width: pxToRem(290); // Keeps items inside bounds
     &:hover,
     &:focus {
       background: $dropdown-hover-bg;
-      color: darken($dropdown-color, 8%);
+      color: color.adjust($dropdown-color, $lightness: -8%);
       outline: none;
     }
     &.fw-bold    { font-weight: bold; }

--- a/app/static/scss/components/_flash_messages.scss
+++ b/app/static/scss/components/_flash_messages.scss
@@ -1,4 +1,7 @@
 // Flash message styling ported from old CSS (main1.css)
+@use '../abstracts/variables' as *;
+@use '../abstracts/mixins' as *;
+@use 'sass:color';
 
 .flash-message {
   background-color: $flash-highlight-color;
@@ -32,5 +35,5 @@
 }
 
 .blue_button:hover {
-  background-color: darken($primary-color, 10%);
+  background-color: color.adjust($primary-color, $lightness: -10%);
 }

--- a/app/static/scss/components/_navbar.scss
+++ b/app/static/scss/components/_navbar.scss
@@ -1,5 +1,5 @@
-@import '../abstracts/functions';
-@import '../abstracts/mixins';
+@use '../abstracts/functions' as *;
+@use '../abstracts/mixins' as *;
 
 /* 1. Navbar container */
 .navbar {

--- a/app/static/scss/components/_notification-dropdown.scss
+++ b/app/static/scss/components/_notification-dropdown.scss
@@ -1,5 +1,5 @@
-@import '../abstracts/functions';
-@import '../abstracts/mixins';
+@use '../abstracts/functions' as *;
+@use '../abstracts/mixins' as *;
 
 // Notification Bell dropdown
 #notifBell {

--- a/app/static/scss/components/_shoutboard.scss
+++ b/app/static/scss/components/_shoutboard.scss
@@ -1,5 +1,6 @@
-@import '../abstracts/functions';
-@import '../abstracts/mixins';
+@use '../abstracts/functions' as *;
+@use '../abstracts/mixins' as *;
+@use "../abstracts/variables" as *;
 
 /*==============================================================================
   Shout Board / Recent Activity Styles

--- a/app/static/scss/components/_sponsors-modal.scss
+++ b/app/static/scss/components/_sponsors-modal.scss
@@ -1,5 +1,7 @@
-@import '../abstracts/functions';  // pxToRem
-@import '../abstracts/mixins';     // respond, transition
+@use '../abstracts/functions' as *;  // pxToRem
+@use '../abstracts/mixins' as *;     // respond, transition
+@use '../abstracts/variables' as *;
+@use 'sass:color';
 
 // Game Sponsors Modal Styles
 #sponsorsModal {
@@ -101,7 +103,7 @@
                 border-radius: pxToRem(4);
                 text-decoration: none;
                 text-align: center;
-                &:hover { background-color: darken($secondary-color, 10%); }
+                &:hover { background-color: color.adjust($secondary-color, $lightness: -10%); }
               }
             }
           }
@@ -148,7 +150,7 @@
         border-radius: pxToRem(4);
         text-decoration: none;
         @include transition(background-color 0.2s ease);
-        &:hover { background-color: darken($primary-color, 10%); }
+        &:hover { background-color: color.adjust($primary-color, $lightness: -10%); }
       }
     }
   }

--- a/app/static/scss/components/_utilities.scss
+++ b/app/static/scss/components/_utilities.scss
@@ -1,4 +1,4 @@
-@import '../abstracts/functions'; // pxToRem()
+@use '../abstracts/functions' as *; // pxToRem()
 
 .bold-item {
   font-weight: bold;

--- a/app/static/scss/layout/_footer.scss
+++ b/app/static/scss/layout/_footer.scss
@@ -1,5 +1,6 @@
-@import '../abstracts/mixins';   // for any transition mixin, if needed
-@import '../abstracts/functions';// for pxToRem()
+@use '../abstracts/mixins' as *;   // for any transition mixin, if needed
+@use '../abstracts/functions' as *; // for pxToRem()
+@use 'sass:color';
 
 .footer {
   // 1. Base footer container
@@ -82,7 +83,7 @@
         font-size: pxToRem(14);
         &:hover {
           text-decoration: none;
-          color: lighten(#fff, 10%);
+          color: color.adjust(#fff, $lightness: 10%);
         }
       }
       margin-bottom: pxToRem(20);

--- a/app/static/scss/layout/_header.scss
+++ b/app/static/scss/layout/_header.scss
@@ -1,3 +1,4 @@
+@use "../abstracts/variables" as *;
 .site-header {
     background-color: $primary-color;
     color: #fff;

--- a/app/static/scss/layout/_layout.scss
+++ b/app/static/scss/layout/_layout.scss
@@ -1,5 +1,5 @@
 @use 'sass:math';
-@import '../abstracts/mixins';
+@use '../abstracts/mixins' as *;
 
 body {
   display: flex;

--- a/app/static/scss/main.scss
+++ b/app/static/scss/main.scss
@@ -1,9 +1,9 @@
 @use 'sass:math';
 
 // 1. ABSTRACTS
-@import 'abstracts/variables';
-@import 'abstracts/functions';
-@import 'abstracts/mixins';
+@use 'abstracts/variables' as *;
+@use 'abstracts/functions' as *;
+@use 'abstracts/mixins' as *;
 
 // 2. BASE
 // Use Bootstrap's reboot and typography
@@ -11,43 +11,43 @@
 
 // 3. LAYOUT
 // Bootstrap grid provides container, row, and col utilities
-@import 'layout/header';
-@import 'layout/layout';
-@import 'layout/footer';
+@use 'layout/header';
+@use 'layout/layout';
+@use 'layout/footer';
 
 // 4. COMPONENTS
 // Use Bootstrap containers instead
-@import 'components/notification-dropdown';
-@import 'components/navbar';
-@import 'components/dropdown';
+@use 'components/notification-dropdown';
+@use 'components/navbar';
+@use 'components/dropdown';
 // Use Bootstrap button and form styles
-@import 'components/modals';
-@import 'components/join_custom_game_modal';
-@import 'components/contact_modal';
-@import 'components/register_modal';
-@import 'components/badge_modal';
-@import 'components/loading_modal';
-@import 'components/all_submissions_modal';
-@import 'components/delete_game_modal';
-@import 'components/quest_detail_modal';
-@import 'components/leaderboard_modal';
-@import 'components/sponsors-modal';
-@import 'components/user_profile_modal';
-@import 'components/badges';
-@import 'components/badge-bar';
-@import 'components/utilities';
-@import 'components/shoutboard';
-@import 'components/notifications';
-@import 'components/flash_messages';
+@use 'components/modals';
+@use 'components/join_custom_game_modal';
+@use 'components/contact_modal';
+@use 'components/register_modal';
+@use 'components/badge_modal';
+@use 'components/loading_modal';
+@use 'components/all_submissions_modal';
+@use 'components/delete_game_modal';
+@use 'components/quest_detail_modal';
+@use 'components/leaderboard_modal';
+@use 'components/sponsors-modal';
+@use 'components/user_profile_modal';
+@use 'components/badges';
+@use 'components/badge-bar';
+@use 'components/utilities';
+@use 'components/shoutboard';
+@use 'components/notifications';
+@use 'components/flash_messages';
 
 // 5. PAGES
-@import 'pages/index';
-@import 'pages/game';
-@import 'pages/profile';
-@import 'pages/quest';
-@import 'pages/submission';
-@import 'pages/submit_photo';
+@use 'pages/index';
+@use 'pages/game';
+@use 'pages/profile';
+@use 'pages/quest';
+@use 'pages/submission';
+@use 'pages/submit_photo';
 
 // 6. UTILS
-@import 'utils/animations';
-@import 'utils/responsive';
+@use 'utils/animations';
+@use 'utils/responsive';

--- a/app/static/scss/pages/_index.scss
+++ b/app/static/scss/pages/_index.scss
@@ -1,3 +1,4 @@
+@use "../abstracts/functions" as *;
 .hero-image {
   max-width: 100%;
   height: auto;

--- a/app/static/scss/pages/_profile.scss
+++ b/app/static/scss/pages/_profile.scss
@@ -1,5 +1,5 @@
-@import '../abstracts/functions';
-@import '../abstracts/mixins';
+@use '../abstracts/functions' as *;
+@use '../abstracts/mixins' as *;
 
 .epic-profile-container {
   background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);

--- a/app/static/scss/pages/_quest.scss
+++ b/app/static/scss/pages/_quest.scss
@@ -1,3 +1,4 @@
+@use "../abstracts/variables" as *;
 .quest-page {
     max-width: 800px;
     margin: 0 auto;

--- a/app/static/scss/pages/_submission.scss
+++ b/app/static/scss/pages/_submission.scss
@@ -1,5 +1,7 @@
 // === app/static/scss/pages/_submission.scss ===
 
+@use 'sass:color';
+
 // ── IMAGE CONTAINER ──
 #submissionImageContainer {
   position: relative;
@@ -170,7 +172,7 @@
       // optional: change hover on unliked
       &:not(.active):hover {
         .fa-heart {
-          color: darken(#0d6efd, 10%);
+          color: color.adjust(#0d6efd, $lightness: -10%);
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "questbycycle",
       "version": "1.0.0",
       "devDependencies": {
-        "sass": "^1.75.0",
+        "sass": "^1.89.2",
         "vite": "^6.3.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "vite": "^6.3.5",
-    "sass": "^1.75.0"
+    "sass": "^1.89.2"
   }
 }


### PR DESCRIPTION
## Summary
- replace deprecated `@import` with `@use`
- switch from global `darken`/`lighten` to `sass:color.adjust`
- bump `sass` dependency to `^1.89.2`

## Testing
- `npm install`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6847c57bcaa0832b90415d025c7292dd