### PR TITLE
Fix Sass math import

### DIFF
--- a/app/static/scss/abstracts/_functions.scss
+++ b/app/static/scss/abstracts/_functions.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 // Function to convert px to rem units
 @function pxToRem($px, $base-px: 16) {
     @return math.div($px, $base-px) * 1rem;


### PR DESCRIPTION
## Summary
- import `sass:math` in `_functions.scss` so Vite can find the module

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6847d53890e0832b972e4fc884244ea6