### PR TITLE
Refactor modules to use ES imports

### DIFF
--- a/frontend/modules/all_submissions_modal.js
+++ b/frontend/modules/all_submissions_modal.js
@@ -1,5 +1,6 @@
 
 import { openModal } from './modal_common.js';
+import { getCSRFToken } from '../utils.js';
 
 const PLACEHOLDER_IMAGE =
   window.PLACEHOLDER_IMAGE ||

--- a/frontend/modules/badge_management.js
+++ b/frontend/modules/badge_management.js
@@ -1,3 +1,5 @@
+import { getCSRFToken } from '../utils.js';
+
 // Badge management functions
 document.addEventListener('DOMContentLoaded', () => {
   loadBadges();

--- a/frontend/modules/badge_modal.js
+++ b/frontend/modules/badge_modal.js
@@ -1,5 +1,6 @@
 "use strict";
 import { openModal } from './modal_common.js';
+import { escapeHTML } from '../utils.js';
 
 // Cache all badges in a global variable once loaded
 window.allBadges = window.allBadges || [];

--- a/frontend/modules/forgot_password_modal.js
+++ b/frontend/modules/forgot_password_modal.js
@@ -1,3 +1,5 @@
+import { submitFormJson } from './modal_common.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('forgotForm');
   if (!form) return; // Modal not present
@@ -21,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
     emailErr.style.display   = 'none';
     successDiv.style.display = 'none';
 
-    window.submitFormJson(form)
+    submitFormJson(form)
       .then(({ json }) => {
         if (json.success) {
           successDiv.textContent   = json.message;

--- a/frontend/modules/login_modal.js
+++ b/frontend/modules/login_modal.js
@@ -1,3 +1,5 @@
+import { submitFormJson, openForgotPasswordModal } from './modal_common.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const form     = document.getElementById('loginForm');
   const modal    = document.getElementById('loginModal');
@@ -13,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     pwdError.style.display = 'none';
     forgotDiv.innerHTML   = '';
 
-    window.submitFormJson(form)
+    submitFormJson(form)
       .then(({ json }) => {
         if (json.success) {
           window.location.href = json.redirect;
@@ -25,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
             a.href      = 'javascript:void(0)';
             a.textContent = 'Forgot password?';
             a.className = 'd-block mt-1';
-            a.onclick   = window.openForgotPasswordModal;
+            a.onclick   = openForgotPasswordModal;
             forgotDiv.appendChild(a);
           }
         }

--- a/frontend/modules/manage_quests.js
+++ b/frontend/modules/manage_quests.js
@@ -1,3 +1,4 @@
+import { getCSRFToken } from '../utils.js';
 
     let game_Id = null;
     const VerificationTypes = {

--- a/frontend/modules/modal_common.js
+++ b/frontend/modules/modal_common.js
@@ -396,7 +396,7 @@ export async function fetchAndShowModal(url, modalId) {
 }
 
 // Submit a form via AJAX and return the JSON response
-async function submitFormJson(form) {
+export async function submitFormJson(form) {
   const res = await fetch(form.action, {
     method: form.method || 'POST',
     headers: { 'X-Requested-With': 'XMLHttpRequest' },

--- a/frontend/modules/quest_detail_modal.js
+++ b/frontend/modules/quest_detail_modal.js
@@ -1,5 +1,6 @@
 import { openModal } from './modal_common.js';
 import { resetModalContent } from './modal_common.js';
+import { getCSRFToken } from '../utils.js';
 
 /* ------------------------------------------------------------------ */
 /*  HELPER: read meta-content                                         */

--- a/frontend/modules/reset_password_modal.js
+++ b/frontend/modules/reset_password_modal.js
@@ -1,3 +1,5 @@
+import { submitFormJson } from './modal_common.js';
+
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('resetForm');
     if (!form) return;
@@ -11,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
         errDiv.style.display     = 'none';
         successDiv.style.display = 'none';
 
-        window.submitFormJson(form)
+        submitFormJson(form)
             .then(({ json }) => {
                 if (json.success) {
                     successDiv.textContent   = json.message;

--- a/frontend/modules/submission_detail_modal.js
+++ b/frontend/modules/submission_detail_modal.js
@@ -1,4 +1,5 @@
 import { openModal, closeModal, resetModalContent } from './modal_common.js';
+import { getCSRFToken } from '../utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 

--- a/frontend/modules/submit_photo.js
+++ b/frontend/modules/submit_photo.js
@@ -1,5 +1,6 @@
 
 import { showLoadingModal, hideLoadingModal } from './loading_modal.js';
+import { getCSRFToken } from '../utils.js';
 
 document.addEventListener('DOMContentLoaded', function () {
     const submitPhotoForm = document.getElementById('submitPhotoForm');

--- a/frontend/modules/user_profile_modal.js
+++ b/frontend/modules/user_profile_modal.js
@@ -1,4 +1,5 @@
 import { openModal } from './modal_common.js';
+import { getCSRFToken } from '../utils.js';
 
 function showUserProfileModal(userId) {
   fetch(`/profile/${userId}`)


### PR DESCRIPTION
## Summary
- import utils helper functions in individual modules
- export `submitFormJson` from `modal_common`

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68480dfcacf4832badd4fd7a949d335e