### PR TITLE
Continue refactoring JavaScript to Vite ES modules

### DIFF
--- a/frontend/modules/game_info_modal.js
+++ b/frontend/modules/game_info_modal.js
@@ -1,6 +1,6 @@
 import { fetchAndShowModal } from './modal_common.js';
 
-function showGameInfoModal(gameId) {
+export function showGameInfoModal(gameId) {
     const url = '/games/game-info/' + gameId + '?modal=1';
     fetchAndShowModal(url, 'gameInfoModal');
 }

--- a/frontend/modules/shout_board_modal.js
+++ b/frontend/modules/shout_board_modal.js
@@ -1,6 +1,7 @@
 /* ------------------------------------------------------------------ */
 /*  SHOUT‑BOARD ADMIN MODAL                                           */
 /* ------------------------------------------------------------------ */
+import { closeModal } from './modal_common.js';
 document.addEventListener('DOMContentLoaded', () => {
   const modalId   = 'shoutBoardModal';
   const formEl    = document.getElementById('shoutBoardForm');


### PR DESCRIPTION
## Summary
- convert game info script to ES module
- import closeModal in shout board admin script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68481e1f00d8832b82c44271905759d8