### PR TITLE
Refactor leaderboard modal to lazy loaded ES module

### DIFF
--- a/frontend/layout.js
+++ b/frontend/layout.js
@@ -1,4 +1,3 @@
-import { showLeaderboardModal } from './modules/leaderboard_modal.js';
 
 export function initLayout() {
   if ('serviceWorker' in navigator) {
@@ -103,10 +102,11 @@ export function initLayout() {
 
 
   if (leaderboardLink) {
-    leaderboardLink.addEventListener('click', (e) => {
+    leaderboardLink.addEventListener('click', async (e) => {
       e.preventDefault();
       const gameId = leaderboardLink.getAttribute('data-game-id') || 0;
-      showLeaderboardModal(gameId);
+      const module = await import('./modules/leaderboard_modal.js');
+      module.showLeaderboardModal(gameId);
     });
   }
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -18,7 +18,6 @@ import './modules/game_info_modal.js';
 import './modules/generated_quest.js';
 import './modules/index_management.js';
 import './modules/join_custom_game_modal.js';
-import './modules/leaderboard_modal.js';
 import './modules/loading_modal.js';
 import './modules/login_modal.js';
 import './modules/manage_quests.js';

--- a/frontend/modules/index_management.js
+++ b/frontend/modules/index_management.js
@@ -1,5 +1,4 @@
 import { showLoadingModal, hideLoadingModal } from './loading_modal.js';
-import { showLeaderboardModal } from './leaderboard_modal.js';
 import { showAllSubmissionsModal } from './all_submissions_modal.js';
 import { closeModal } from './modal_common.js';
 const refreshCSRFToken = async () => {
@@ -83,9 +82,10 @@ function updateGameName() {
 document.addEventListener('DOMContentLoaded', () => {
   const leaderboardButton = document.getElementById('leaderboardButton');
   if (leaderboardButton) {
-    leaderboardButton.addEventListener('click', () => {
+    leaderboardButton.addEventListener('click', async () => {
       const gameId = leaderboardButton.getAttribute('data-game-id');
-      showLeaderboardModal(gameId);
+      const module = await import('./leaderboard_modal.js');
+      module.showLeaderboardModal(gameId);
       updateMeter(gameId);
     });
   }

--- a/frontend/modules/leaderboard_modal.js
+++ b/frontend/modules/leaderboard_modal.js
@@ -219,6 +219,5 @@ function updateLeaderboardRows() {
     });
 }
 
-// Make available globally for inline scripts
-window.showLeaderboardModal = showLeaderboardModal;
+
 


### PR DESCRIPTION
## Summary
- remove global export from `leaderboard_modal.js`
- lazy load the leaderboard module in `layout.js` and `index_management.js`
- drop eager import from `main.js`

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684821ecd3cc832b847aeffae4ce1aa9