### PR TITLE
Refactor: add logging and validation

### DIFF
--- a/app/badges.py
+++ b/app/badges.py
@@ -4,6 +4,7 @@ Badge related routes.
 from markupsafe import escape
 import os
 import csv
+import logging
 from flask import Blueprint, current_app, render_template, flash, redirect, url_for, jsonify, request
 from flask_login import login_required, current_user
 from .forms import BadgeForm
@@ -13,6 +14,7 @@ from .models import db, Quest, Badge, UserQuest, Game
 from werkzeug.utils import secure_filename
 
 badges_bp = Blueprint('badges', __name__, template_folder='templates')
+logger = logging.getLogger(__name__)
 
 def sanitize_html(html_content: str) -> str:
     return escape(html_content)
@@ -305,7 +307,7 @@ def bulk_upload():
                 db.session.add(new_badge)
             else:
                 flash(f'Image for badge "{badge_name}" not found.', 'warning')
-                print(f'Image for badge "{badge_name}" not found.')
+                logger.warning('Image for badge "%s" not found.', badge_name)
 
     except Exception:
         flash('Error processing CSV file.', 'danger')

--- a/app/main.py
+++ b/app/main.py
@@ -674,7 +674,7 @@ def _coerce_to_list(raw: Any) -> List[str]:
     Turn anything—string, list, tuple, JSON literal—into a Python list of strings.
     """
                   
-    if isinstance(raw, (list, tuple)):
+    if isinstance(raw, (list, tuple, set)):
         return list(raw)
 
                          
@@ -864,11 +864,11 @@ def resize_image():
 
                                                       
     try:
-        width = int(float(width_arg))
+        width = int(width_arg)
     except (TypeError, ValueError):
-        return jsonify({'error': "Invalid request: 'width' must be a number"}), 400
+        return jsonify({'error': "Invalid request: 'width' must be a positive integer"}), 400
 
-    if not image_path or not width:
+    if not image_path or width <= 0:
         return jsonify({'error': "Invalid request: Missing 'path' or 'width'"}), 400
 
     try:


### PR DESCRIPTION
## Summary
- use logging in badges import flow
- validate resize width arg is a positive integer
- expand `_coerce_to_list` to handle sets

## Testing
- `pytest tests/test_utils.py::test_save_submission_video_invalid -q`
- `PYTHONPATH=. FFMPEG_PATH=/usr/bin/false pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68482269f354832baa5f172f356e1cf9