### PR TITLE
Replace print and console statements with logger

### DIFF
--- a/frontend/layout.js
+++ b/frontend/layout.js
@@ -1,4 +1,6 @@
 
+import logger from './logger.js';
+
 export function initLayout() {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker
@@ -21,13 +23,13 @@ export function initLayout() {
         if ('SyncManager' in window) {
           registration.sync
             .register('sync-notifications')
-            .catch((err) => console.error('Sync registration failed:', err));
+            .catch((err) => logger.error('Sync registration failed:', err));
         }
 
         if (registration.periodicSync) {
           registration.periodicSync
             .register('periodic-notifications', { minInterval: 24 * 60 * 60 * 1000 })
-            .catch((err) => console.error('Periodic sync registration failed:', err));
+            .catch((err) => logger.error('Periodic sync registration failed:', err));
         }
 
         if ('PushManager' in window && Notification.permission === 'default') {
@@ -36,11 +38,11 @@ export function initLayout() {
 
         if ('sync' in registration) {
           registration.sync.register('sync-requests').catch((err) => {
-            console.error('Background sync registration failed:', err);
+            logger.error('Background sync registration failed:', err);
           });
         }
       })
-      .catch((err) => console.error('Service Worker registration failed:', err));
+      .catch((err) => logger.error('Service Worker registration failed:', err));
 
     navigator.serviceWorker.addEventListener('message', (event) => {
       if (event.data.type === 'UPDATE_AVAILABLE') {

--- a/frontend/logger.js
+++ b/frontend/logger.js
@@ -1,0 +1,8 @@
+const logger = {
+  log: (...args) => console.log(...args),
+  error: (...args) => console.error(...args),
+  warn: (...args) => console.warn(...args),
+  info: (...args) => console.info(...args),
+  debug: (...args) => console.debug(...args)
+};
+export default logger;

--- a/frontend/modules/all_submissions_modal.js
+++ b/frontend/modules/all_submissions_modal.js
@@ -2,6 +2,7 @@
 import { openModal } from './modal_common.js';
 import { getCSRFToken } from '../utils.js';
 import { showSubmissionDetail } from './submission_detail_modal.js';
+import logger from '../logger.js';
 
 const PLACEHOLDER_IMAGE =
   window.PLACEHOLDER_IMAGE ||
@@ -40,7 +41,7 @@ function fetchSubmissions() {
             submissionsPage += 1;
         })
         .catch(error => {
-            console.error('Error fetching all submissions:', error);
+            logger.error('Error fetching all submissions:', error);
             alert('Error fetching all submissions: ' + error.message);
         });
 }
@@ -48,7 +49,7 @@ function fetchSubmissions() {
 function displayAllSubmissions(submissions, isAdmin, append = false) {
     const container = document.getElementById('allSubmissionsContainer');
     if (!container) {
-        console.error('allSubmissionsContainer element not found.');
+        logger.error('allSubmissionsContainer element not found.');
         return;  // Exit if the container element is not found
     }
     if (!append) {
@@ -158,7 +159,7 @@ function deleteSubmission(submissionId) {
             }
         })
         .catch(error => {
-            console.error('Error deleting submission:', error);
+            logger.error('Error deleting submission:', error);
             alert('Error during deletion: ' + error.message);
         });
 }

--- a/frontend/modules/badge_management.js
+++ b/frontend/modules/badge_management.js
@@ -1,4 +1,5 @@
 import { getCSRFToken } from '../utils.js';
+import logger from '../logger.js';
 
 // Badge management functions
 document.addEventListener('DOMContentLoaded', () => {
@@ -41,7 +42,7 @@ function loadBadges() {
                 badgesBody.appendChild(row);
             });
         })
-        .catch(error => console.error('Failed to load badges:', error));
+        .catch(error => logger.error('Failed to load badges:', error));
 }
 
 function toggleForm(formId) {
@@ -79,7 +80,7 @@ function setCategoryOptions(currentCategory) {
             return select;
         })
         .catch(error => {
-            console.error('Error fetching categories:', error);
+            logger.error('Error fetching categories:', error);
             const select = document.createElement('select');
             select.className = 'form-control badge-category-select';
             const noneOption = document.createElement('option');
@@ -94,7 +95,7 @@ function setCategoryOptions(currentCategory) {
 function editBadge(badgeId) {
     const row = document.querySelector(`tr[data-badge-id='${badgeId}']`);
     if (!row) {
-        console.error(`Badge row with ID ${badgeId} not found.`);
+        logger.error(`Badge row with ID ${badgeId} not found.`);
         return;
     }
     const nameCell = row.querySelector('.badge-name');
@@ -129,7 +130,7 @@ function editBadge(badgeId) {
         fileInput.className = 'form-control-file badge-image-input';
         imageContainer.appendChild(fileInput);
     } else {
-        console.error('Could not find badge-image-manage cell');
+        logger.error('Could not find badge-image-manage cell');
     }
 
     // 4) Call setCategoryOptions(...) to build the <select> for Category
@@ -176,7 +177,7 @@ function saveBadge(badgeId) {
             alert('Failed to update badge: ' + data.message);
         }
     })
-    .catch(error => console.error('Error updating badge:', error));
+    .catch(error => logger.error('Error updating badge:', error));
 }
 
 
@@ -198,7 +199,7 @@ function deleteBadge(badgeId) {
         }
     })
     .catch(error => {
-        console.error('Error deleting badge:', error);
+        logger.error('Error deleting badge:', error);
         alert('Error deleting badge. Please check console for details.');
     });
 }
@@ -220,5 +221,5 @@ function uploadImages() {
             alert('Failed to upload images: ' + data.message);
         }
     })
-    .catch(error => console.error('Error uploading images:', error));
+    .catch(error => logger.error('Error uploading images:', error));
 }

--- a/frontend/modules/badge_modal.js
+++ b/frontend/modules/badge_modal.js
@@ -1,6 +1,7 @@
 "use strict";
 import { openModal } from './modal_common.js';
 import { escapeHTML } from '../utils.js';
+import logger from '../logger.js';
 
 // Cache all badges in a global variable once loaded
 window.allBadges = window.allBadges || [];
@@ -57,7 +58,7 @@ async function ensureBadgeCache() {
     try {
       await fetchAllBadges();
     } catch (err) {
-      console.error('Error loading badges:', err);
+      logger.error('Error loading badges:', err);
       window.allBadges = [];
     }
   }
@@ -97,7 +98,7 @@ function populateBadgeModal(badge, requiredCount, currentUserCompletions, taskLi
   const modalText  = document.getElementById('badgeModalText');
 
   if (!modalTitle || !modalImage || !modalText) {
-    console.error('Badge modal elements missing');
+    logger.error('Badge modal elements missing');
     return;
   }
 
@@ -159,7 +160,7 @@ export async function openBadgeModal(element) {
     try {
       currentUserCompletions = await fetchUserCompletions(taskId);
     } catch (err) {
-      console.error('Error fetching user completions:', err);
+      logger.error('Error fetching user completions:', err);
     }
   }
 

--- a/frontend/modules/delete_game_modal.js
+++ b/frontend/modules/delete_game_modal.js
@@ -1,4 +1,5 @@
 import { openModal } from './modal_common.js';
+import logger from '../logger.js';
 
 let deleteInterval;
 
@@ -11,7 +12,7 @@ export function openDeleteGameModal(gameId) {
   const confirmBtn = document.getElementById('deleteGameConfirmBtn');
 
   if (!modal || !form || !input || !countdown || !timerSpan || !confirmBtn) {
-    console.warn('Delete game modal elements missing');
+    logger.warn('Delete game modal elements missing');
     return;
   }
 

--- a/frontend/modules/generated_quest.js
+++ b/frontend/modules/generated_quest.js
@@ -1,4 +1,5 @@
 import { openModal } from './modal_common.js';
+import logger from '../logger.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const buttons = document.querySelectorAll('button[data-game-id]');
@@ -66,9 +67,9 @@ document.addEventListener('DOMContentLoaded', () => {
                                     // Handle the response here
                                     window.location.href = '/';
 
-                                    console.log(result);
+                                    logger.log(result);
                                 }).catch(error => {
-                                    console.error('Error:', error);
+                                    logger.error('Error:', error);
                                 });
                             });
                         }
@@ -80,15 +81,15 @@ document.addEventListener('DOMContentLoaded', () => {
                         const aiBadgeFilenameInput = document.getElementById('aiBadgeFilename');
                     
                         if (!generateAIImageBtn || !badgeDescriptionInput || !aiBadgeImage || !aiBadgeFilenameInput) {
-                            console.error("One or more elements not found in the DOM");
+                            logger.error("One or more elements not found in the DOM");
                             return;
                         }
                     
                         generateAIImageBtn.addEventListener('click', function() {
-                            console.log("Generate AI Image button clicked");
+                            logger.log("Generate AI Image button clicked");
                     
                             const badgeDescription = badgeDescriptionInput.value;
-                            console.log("Badge Description:", badgeDescription);
+                            logger.log("Badge Description:", badgeDescription);
                     
                             if (!badgeDescription) {
                                 alert('Please enter a badge description first.');
@@ -105,7 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             })
                             .then(response => response.json())
                             .then(data => {
-                                console.log("Response data:", data);
+                                logger.log("Response data:", data);
                                 if (data.error) {
                                     alert('Error generating badge image: ' + data.error);
                                 } else {
@@ -117,7 +118,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                 }
                             })
                             .catch(error => {
-                                console.error('Fetch error:', error);
+                                logger.error('Fetch error:', error);
                                 alert('Error: ' + error);
                             });
                         });
@@ -128,7 +129,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
             });
         } else {
-            console.error("Form '#questCreationForm' not found.");
+            logger.error("Form '#questCreationForm' not found.");
         }
     }
 });

--- a/frontend/modules/index_management.js
+++ b/frontend/modules/index_management.js
@@ -1,6 +1,7 @@
 import { showLoadingModal, hideLoadingModal } from './loading_modal.js';
 import { showAllSubmissionsModal } from './all_submissions_modal.js';
 import { closeModal } from './modal_common.js';
+import logger from '../logger.js';
 const refreshCSRFToken = async () => {
   try {
     const res  = await fetch('/refresh-csrf');
@@ -9,7 +10,7 @@ const refreshCSRFToken = async () => {
       .querySelector('meta[name="csrf-token"]')
       .setAttribute('content', data.csrf_token);
   } catch (err) {
-    console.error('Error refreshing CSRF token:', err);
+    logger.error('Error refreshing CSRF token:', err);
   }
 };
 
@@ -35,7 +36,7 @@ const updateMeter = async gameId => {
       label.innerText = `Remaining Reduction: ${remainingPoints} / ${gameGoal}`;
     }
   } catch (err) {
-    console.error('Failed to update meter:', err);
+    logger.error('Failed to update meter:', err);
   }
 };
 
@@ -59,7 +60,7 @@ function updateGameName() {
   fetch(`/games/get_game/${gameId}`, { credentials: 'same-origin' })
     .then(response => {
       if (!response.ok) {
-        console.error(
+        logger.error(
           `Failed fetching game name; URL returned status ${response.status} (${response.statusText})`
         );
         // show a user-friendly message in the header
@@ -73,7 +74,7 @@ function updateGameName() {
       gameNameHeader.textContent = data.name || "Game Not Found";
     })
     .catch(error => {
-      console.error("Error retrieving game name:", error);
+      logger.error("Error retrieving game name:", error);
       gameNameHeader.textContent = "Error Loading Game";
     });
 }

--- a/frontend/modules/leaderboard_modal.js
+++ b/frontend/modules/leaderboard_modal.js
@@ -1,6 +1,7 @@
 import { openModal } from './modal_common.js';
 import { showUserProfileModal } from './user_profile_modal.js';
 import { showAllSubmissionsModal } from './all_submissions_modal.js';
+import logger from '../logger.js';
 
 let leaderboardData = null;
 let leaderboardMetric = 'points';
@@ -9,7 +10,7 @@ let leaderboardBody;
 export function showLeaderboardModal(selectedGameId) {
     const leaderboardContent = document.getElementById('leaderboardModalContent');
     if (!leaderboardContent) {
-        console.error('Leaderboard modal content element not found. Cannot proceed with displaying leaderboard.');
+        logger.error('Leaderboard modal content element not found. Cannot proceed with displaying leaderboard.');
         alert('Leaderboard modal content element not found. Please ensure the page has loaded completely and the correct ID is used.');
         return;
     }
@@ -32,7 +33,7 @@ export function showLeaderboardModal(selectedGameId) {
             openModal('leaderboardModal');
         })
         .catch(error => {
-            console.error('Failed to load leaderboard:', error);
+            logger.error('Failed to load leaderboard:', error);
             alert('Failed to load leaderboard data. Please try again.');
         });
 }

--- a/frontend/modules/loading_modal.js
+++ b/frontend/modules/loading_modal.js
@@ -1,10 +1,12 @@
+import logger from '../logger.js';
+
 export function showLoadingModal() {
-    console.debug('Showing loading modal');
+    logger.debug('Showing loading modal');
     document.getElementById('loadingModal').style.display = 'flex';
 }
 
 export function hideLoadingModal() {
-    console.debug('Hiding loading modal');
+    logger.debug('Hiding loading modal');
     document.getElementById('loadingModal').style.display = 'none';
 }
 

--- a/frontend/modules/manage_quests.js
+++ b/frontend/modules/manage_quests.js
@@ -1,4 +1,5 @@
 import { getCSRFToken } from '../utils.js';
+import logger from '../logger.js';
 
     let game_Id = null;
     const VerificationTypes = {
@@ -35,7 +36,7 @@ import { getCSRFToken } from '../utils.js';
             const data = await response.json();
             badges = data.badges || [];
         } catch (error) {
-            console.error('Error fetching badges:', error);
+            logger.error('Error fetching badges:', error);
         }
     }
 
@@ -58,7 +59,7 @@ import { getCSRFToken } from '../utils.js';
                 alert('Failed to add quest');
             }
         })
-        .catch(error => console.error('Error:', error));
+        .catch(error => logger.error('Error:', error));
     }
 
     function editQuest(questId) {
@@ -117,13 +118,13 @@ import { getCSRFToken } from '../utils.js';
                         }
                     })
                     .catch(error => {
-                        console.error('Error:', error);
+                        logger.error('Error:', error);
                         alert('Failed to delete all quests. Please check the console for more details.');
                     });
                 }
             })
             .catch(error => {
-                console.error('Error fetching game title:', error);
+                logger.error('Error fetching game title:', error);
                 alert('Failed to fetch game title. Please check the console for more details.');
             });
         }
@@ -288,7 +289,7 @@ import { getCSRFToken } from '../utils.js';
             }
         })
         .catch(error => {
-            console.error('Error updating quest:', error);
+            logger.error('Error updating quest:', error);
             alert('Error updating quest. Please check console for details.');
         });
     }
@@ -353,7 +354,7 @@ import { getCSRFToken } from '../utils.js';
             });
 
         })
-        .catch(error => console.error('Failed to load quests:', error));
+        .catch(error => logger.error('Failed to load quests:', error));
     }
 
     function deleteQuest(questId) {
@@ -377,7 +378,7 @@ import { getCSRFToken } from '../utils.js';
             }
         })
         .catch(error => {
-            console.error('Error:', error);
+            logger.error('Error:', error);
             alert('Failed to delete quest. Please check the console for more details.');
         });
     }
@@ -409,7 +410,7 @@ import { getCSRFToken } from '../utils.js';
             }
         })
         .catch(error => {
-            console.error('Error importing quests:', error);
+            logger.error('Error importing quests:', error);
         });
     }
 
@@ -426,7 +427,7 @@ import { getCSRFToken } from '../utils.js';
             window.open(imageFilename, '_blank');
         })
         .catch(error => {
-            console.error('Error generating QR code:', error);
+            logger.error('Error generating QR code:', error);
             alert('Failed to generate QR code. Please check console for more details.');
         });
     }

--- a/frontend/modules/modal_common.js
+++ b/frontend/modules/modal_common.js
@@ -1,10 +1,12 @@
+import logger from '../logger.js';
+
 let topZIndex = 3000;
 let scrollY = 0;
 
 export function openModal(modalId) {
   const modal = document.getElementById(modalId);
   if (!modal) {
-    console.error(`Modal ${modalId} not found`);
+    logger.error(`Modal ${modalId} not found`);
     return;
   }
 
@@ -260,7 +262,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 window.location.pathname
             );
         } else {
-            console.warn('show_reset=1 present but no token in URL');
+            logger.warn('show_reset=1 present but no token in URL');
         }
     }
 });
@@ -315,7 +317,7 @@ document.addEventListener('DOMContentLoaded', () => {
           gameId = candidate;
         }
       } catch (e) {
-        console.warn('Failed to parse next URL for gameId:', e);
+        logger.warn('Failed to parse next URL for gameId:', e);
       }
     }
   }
@@ -353,7 +355,7 @@ document.addEventListener('DOMContentLoaded', () => {
         gameId = candidate;
       }
     } catch (e) {
-      console.warn('Could not parse next URL for gameId:', e);
+      logger.warn('Could not parse next URL for gameId:', e);
     }
   }
 
@@ -384,13 +386,13 @@ export async function fetchAndShowModal(url, modalId) {
     tmp.innerHTML = html.trim();
     const modalEl = tmp.firstElementChild;
     if (!modalEl || modalEl.id !== modalId) {
-      console.warn(`Expected first element to be #${modalId}`, modalEl);
+      logger.warn(`Expected first element to be #${modalId}`, modalEl);
     }
     document.body.appendChild(modalEl);
 
     openModal(modalId);
   } catch (err) {
-    console.error(`Error loading ${modalId} from ${url}:`, err);
+    logger.error(`Error loading ${modalId} from ${url}:`, err);
     alert('Failed to load data. Please try again later.');
   }
 }
@@ -416,7 +418,7 @@ document.addEventListener('click', e => {
   const url      = button.getAttribute('data-modal-url');
   const modalId  = button.getAttribute('data-modal-id');
   if (!url || !modalId) {
-    console.error('data-modal-url or data-modal-id missing', button);
+    logger.error('data-modal-url or data-modal-id missing', button);
     return;
   }
   fetchAndShowModal(url, modalId);

--- a/frontend/modules/notifications.js
+++ b/frontend/modules/notifications.js
@@ -1,5 +1,6 @@
 import { showUserProfileModal } from './user_profile_modal.js';
 import { showSubmissionDetail } from './submission_detail_modal.js';
+import logger from '../logger.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   // --------------------------------------------------------------
@@ -85,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
       try {
         ({ text, onClick } = handler(n.payload));
       } catch (e) {
-        console.error(`Error in handler for ${n.type}:`, e);
+        logger.error(`Error in handler for ${n.type}:`, e);
       }
     }
 
@@ -105,7 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
       </small>`;
     a.addEventListener('click', async (e) => {
       e.preventDefault();
-      try { await onClick(); } catch (err) { console.error(err); }
+      try { await onClick(); } catch (err) { logger.error(err); }
     });
     return a;
   }
@@ -151,13 +152,13 @@ document.addEventListener('DOMContentLoaded', () => {
       );
     } catch (err) {
       loadingLi.textContent = 'Network error.';
-      console.error(err);
+      logger.error(err);
       return;
     }
 
     if (!resp.ok) {
       loadingLi.textContent = 'Error loading.';
-      console.error('Status:', resp.status, resp.statusText);
+      logger.error('Status:', resp.status, resp.statusText);
       return;
     }
 

--- a/frontend/modules/push.js
+++ b/frontend/modules/push.js
@@ -1,3 +1,5 @@
+import logger from '../logger.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   if (
     typeof window === 'undefined' ||
@@ -16,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
       try {
         ({ public_key } = await res.json());
       } catch (err) {
-        console.error('Push setup failed', err);
+        logger.error('Push setup failed', err);
         return;
       }
       if (!public_key) return;
@@ -34,7 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify({ subscription: sub }),
       });
     } catch (err) {
-      console.error('Push setup failed', err);
+      logger.error('Push setup failed', err);
     }
   });
 });

--- a/frontend/modules/quest_detail_modal.js
+++ b/frontend/modules/quest_detail_modal.js
@@ -2,6 +2,7 @@ import { openModal } from './modal_common.js';
 import { resetModalContent } from './modal_common.js';
 import { getCSRFToken } from '../utils.js';
 import { showSubmissionDetail } from './submission_detail_modal.js';
+import logger from '../logger.js';
 
 /* ------------------------------------------------------------------ */
 /*  HELPER: read meta-content                                         */
@@ -36,7 +37,7 @@ export function openQuestDetailModal(questId) {
           nextEligibleTime
         )
       ) {
-        console.error('populateQuestDetails – required element missing');
+        logger.error('populateQuestDetails – required element missing');
         return;
       }
 
@@ -52,7 +53,7 @@ export function openQuestDetailModal(questId) {
       fetchQuestSubmissions(questId);
     })
     .catch(err => {
-      console.error('Error opening quest detail modal:', err);
+      logger.error('Error opening quest detail modal:', err);
       alert('Sign in to view quest details.');
     });
 }
@@ -71,7 +72,7 @@ function refreshQuestDetailModal(questId) {
           nextEligibleTime
         )
       ) {
-        console.error('populateQuestDetails – required element missing');
+        logger.error('populateQuestDetails – required element missing');
         return;
       }
 
@@ -86,7 +87,7 @@ function refreshQuestDetailModal(questId) {
       fetchQuestSubmissions(questId);
     })
     .catch(err => {
-      console.error('Failed to refresh quest detail modal:', err);
+      logger.error('Failed to refresh quest detail modal:', err);
     });
 }
 
@@ -127,7 +128,7 @@ function populateQuestDetails(quest, userCompletionCount, canVerify, questId, ne
 
     for (let key in elements) {
         if (!elements[key]) {
-            console.error(`Error: Missing element ${key}`);
+            logger.error(`Error: Missing element ${key}`);
             return false;
         }
     }
@@ -189,7 +190,7 @@ function populateQuestDetails(quest, userCompletionCount, canVerify, questId, ne
 function ensureDynamicElementsExistAndPopulate(quest, userCompletionCount, nextEligibleTime, canVerify) {
     const parentElement = document.querySelector('.user-quest-data');
     if (!parentElement) {
-        console.error('Parent element .user-quest-data not found');
+        logger.error('Parent element .user-quest-data not found');
         return;
     }
 
@@ -237,7 +238,7 @@ function formatTimeDiff(ms) {
 function manageVerificationSection(questId, canVerify, verificationType, nextEligibleTime) {
     const userQuestData = document.querySelector('.user-quest-data');
     if (!userQuestData) {
-        console.error('Parent element .user-quest-data not found');
+        logger.error('Parent element .user-quest-data not found');
         return;
     }
     userQuestData.innerHTML = '';
@@ -364,13 +365,13 @@ function toggleVerificationForm(questId) {
 function setupSubmissionForm(questId) {
     const container = document.getElementById(`verifyQuestForm-${questId}`);
     if (!container) {
-        console.error("Form container not found for quest ID:", questId);
+        logger.error("Form container not found for quest ID:", questId);
         return;
     }
 
     const form = container.querySelector('form');
     if (!form) {
-        console.error("Form element missing for quest ID:", questId);
+        logger.error("Form element missing for quest ID:", questId);
         return;
     }
 
@@ -472,7 +473,7 @@ async function submitQuestDetails(event, questId) {
     refreshQuestDetailModal(questId);
     event.target.reset();
   } catch (err) {
-    console.error('Submission error:', err);
+    logger.error('Submission error:', err);
     alert(`Error during submission: ${err.message}`);
   } finally {
     isSubmitting = false;
@@ -551,14 +552,14 @@ async function fetchQuestSubmissions(questId) {
 
     distributeImages(gallery);
   } catch (err) {
-    console.error('Failed to fetch submissions:', err);
+    logger.error('Failed to fetch submissions:', err);
     alert('Could not load submissions. Please try again.');
   }
 }
 
 function isValidImageUrl(url) {
     if (!url) {
-        console.error(`Invalid URL detected: ${url}`);
+        logger.error(`Invalid URL detected: ${url}`);
         return false;
     }
     try {
@@ -571,7 +572,7 @@ function isValidImageUrl(url) {
             return allowedExtensions.some(ext => parsedUrl.pathname.toLowerCase().endsWith(ext));
         }
     } catch (e) {
-        console.error(`Invalid URL detected: ${url}`);
+        logger.error(`Invalid URL detected: ${url}`);
         return false;
     }
     return false;
@@ -580,7 +581,7 @@ function isValidImageUrl(url) {
 function distributeImages(images) {
     const board = document.getElementById('submissionBoard');
     if (!board) {
-        console.error('submissionBoard element not found');
+        logger.error('submissionBoard element not found');
         return;
     }
     board.innerHTML = '';

--- a/frontend/modules/register_modal.js
+++ b/frontend/modules/register_modal.js
@@ -1,3 +1,5 @@
+import logger from '../logger.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const emailInput = document.getElementById('registerEmail');
   if (!emailInput) return; // Modal not included on this page
@@ -44,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }  
       })  
       .catch(err => {  
-        console.error('Error checking email:', err);  
+        logger.error('Error checking email:', err);  
         loginSection.style.display = 'none';  
       });  
   });  
@@ -90,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }  
     })  
     .catch(err => {  
-      console.error('Login error:', err);  
+      logger.error('Login error:', err);  
       errorDiv.textContent = 'An error occurred. Please try again.';  
       errorDiv.style.display = 'block';  
     });  

--- a/frontend/modules/reset_password_modal.js
+++ b/frontend/modules/reset_password_modal.js
@@ -1,4 +1,5 @@
 import { submitFormJson } from './modal_common.js';
+import logger from '../logger.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('resetForm');
@@ -31,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             })
             .catch(err => {
-                console.error('Reset-password AJAX error:', err);
+                logger.error('Reset-password AJAX error:', err);
                 form.submit();
             });
     });

--- a/frontend/modules/shout_board_modal.js
+++ b/frontend/modules/shout_board_modal.js
@@ -2,6 +2,7 @@
 /*  SHOUT‑BOARD ADMIN MODAL                                           */
 /* ------------------------------------------------------------------ */
 import { closeModal } from './modal_common.js';
+import logger from '../logger.js';
 document.addEventListener('DOMContentLoaded', () => {
   const modalId   = 'shoutBoardModal';
   const formEl    = document.getElementById('shoutBoardForm');
@@ -40,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
         location.reload();
       })
       .catch(err => {
-        console.error('Failed to post shout:', err);
+        logger.error('Failed to post shout:', err);
         alert('Could not post. Please try again.');
       });
   });

--- a/frontend/modules/submit_photo.js
+++ b/frontend/modules/submit_photo.js
@@ -1,12 +1,13 @@
 
 import { showLoadingModal, hideLoadingModal } from './loading_modal.js';
 import { getCSRFToken } from '../utils.js';
+import logger from '../logger.js';
 
 document.addEventListener('DOMContentLoaded', function () {
     const submitPhotoForm = document.getElementById('submitPhotoForm');
 
     if (!submitPhotoForm) {
-        console.error('submitPhotoForm element not found on page.');
+        logger.error('submitPhotoForm element not found on page.');
         return;
     }
 
@@ -61,7 +62,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         })
         .catch(error => {
-            console.error("Submission error:", error);
+            logger.error("Submission error:", error);
             displayFlashMessage('Error during submission: ' + error.message, 'error');
         })
         .finally(() => {
@@ -80,7 +81,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 </div>
             `;
         } else {
-            console.warn('Flash messages container not found.');
+            logger.warn('Flash messages container not found.');
         }
     }
 });

--- a/frontend/modules/user_profile_modal.js
+++ b/frontend/modules/user_profile_modal.js
@@ -1,19 +1,20 @@
 import { openModal } from './modal_common.js';
 import { getCSRFToken } from '../utils.js';
+import logger from '../logger.js';
 
 export function showUserProfileModal(userId) {
   fetch(`/profile/${userId}`)
     .then(r => r.json())
     .then(data => {
       if (!data.riding_preferences_choices) {
-        console.error('Riding preferences choices missing.');
+        logger.error('Riding preferences choices missing.');
         return;
       }
 
       const detailsContainer = document.getElementById('userProfileDetails');
 
       if (!detailsContainer) {
-        console.error('Profile details containers not found');
+        logger.error('Profile details containers not found');
         return;
       }
 
@@ -324,7 +325,7 @@ export function showUserProfileModal(userId) {
           });
 
           if (!res.ok) {
-            console.error('Follow toggle failed:', await res.text());
+            logger.error('Follow toggle failed:', await res.text());
             return;
           }
           following = !following;
@@ -356,7 +357,7 @@ export function showUserProfileModal(userId) {
       }
     })
     .catch(err => {
-      console.error('Failed to load profile:', err);
+      logger.error('Failed to load profile:', err);
       alert('Could not load user profile. Please try again.');
     });
 }
@@ -385,7 +386,7 @@ function toggleProfileEditMode() {
   const viewDiv = document.getElementById('profileViewMode');
   const editDiv = document.getElementById('profileEditMode');
   if (!viewDiv || !editDiv) {
-    console.error('Profile edit mode elements missing');
+    logger.error('Profile edit mode elements missing');
     return;
   }
   viewDiv.classList.toggle('d-none');
@@ -399,7 +400,7 @@ function cancelProfileEdit(userId) {
 function saveProfile(userId) {
   const form = document.getElementById('editProfileForm');
   if (!form) {
-    console.error('Edit profile form not found');
+    logger.error('Edit profile form not found');
     return;
   }
   const formData = new FormData(form);
@@ -440,7 +441,7 @@ function saveProfile(userId) {
       }
     })
     .catch(err => {
-      console.error('Error updating profile:', err);
+      logger.error('Error updating profile:', err);
       alert('Failed to update profile. Please try again.');
     });
 }
@@ -448,7 +449,7 @@ function saveProfile(userId) {
 function saveBike(userId) {
   const form = document.getElementById('editBikeForm');
   if (!form) {
-    console.error('Edit bike form not found');
+    logger.error('Edit bike form not found');
     return;
   }
   const formData = new FormData(form);
@@ -473,7 +474,7 @@ function saveBike(userId) {
       }
     })
     .catch(err => {
-      console.error('Error updating bike details:', err);
+      logger.error('Error updating bike details:', err);
       alert('Failed to update bike details. Please try again.');
     });
 }
@@ -496,7 +497,7 @@ function deleteSubmission(submissionId, context, userId) {
       }
     })
     .catch(err => {
-      console.error('Error deleting submission:', err);
+      logger.error('Error deleting submission:', err);
       alert('Error during deletion: ' + err.message);
     });
 }
@@ -529,7 +530,7 @@ function deleteAccount() {
       }
     })
     .catch(err => {
-      console.error('Error deleting account:', err);
+      logger.error('Error deleting account:', err);
       alert('Failed to delete account. Please try again.');
     });
 }

--- a/tests/getgmailtokens.py
+++ b/tests/getgmailtokens.py
@@ -1,4 +1,8 @@
 from google_auth_oauthlib.flow import InstalledAppFlow
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 SCOPES = ['https://mail.google.com/']
 
@@ -20,8 +24,8 @@ def get_tokens():
     )
 
                                    
-    print('Please go to this URL and authorize access:')
-    print(auth_url)
+    logger.info('Please go to this URL and authorize access:')
+    logger.info(auth_url)
 
                                               
     code = input('Enter the authorization code: ')


### PR DESCRIPTION
## Summary
- add a small logger utility for frontend
- convert JS console statements to logger
- replace print statements in `getgmailtokens.py` with logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68482570995c832b8cbc270946d7ff3d