### PR TITLE
Fix global registration of showSubmissionDetail

### DIFF
--- a/frontend/modules/submission_detail_modal.js
+++ b/frontend/modules/submission_detail_modal.js
@@ -382,8 +382,7 @@ document.addEventListener('DOMContentLoaded', () => {
       textarea.parentNode.insertBefore(msg, textarea);
     }
   }
+  // Provide global access for existing inline handlers
+  window.showSubmissionDetail = showSubmissionDetail;
 });
-
-// Provide global access for existing inline handlers
-window.showSubmissionDetail = showSubmissionDetail;
 


### PR DESCRIPTION
## Summary
- ensure `showSubmissionDetail` is attached to `window` **after** initialization

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684828372fd8832ba6bb3b69eab59d21