### PR TITLE
Fix manage quest edit initialization

### DIFF
--- a/frontend/modules/manage_quests.js
+++ b/frontend/modules/manage_quests.js
@@ -12,7 +12,7 @@ import logger from '../logger.js';
 
     let badges = [];  // Define badges globally
 
-    document.addEventListener('DOMContentLoaded', async function() {
+    function initManageQuests() {
         const gameEl = document.getElementById('game_Data');
         if (!gameEl) {
             return;
@@ -25,9 +25,14 @@ import logger from '../logger.js';
         const importBtn = document.getElementById('importQuestsBtn');
         if (importBtn) importBtn.addEventListener('click', importQuests);
 
-        await loadBadges();
-        loadQuests(game_Id);
-    });
+        loadBadges().then(() => loadQuests(game_Id));
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initManageQuests);
+    } else {
+        initManageQuests();
+    }
 
     async function loadBadges() {
         try {


### PR DESCRIPTION
## Summary
- fix DOM ready handling in manage_quests.js

## Testing
- `pytest tests/test_manage_quests_logic.py::test_get_quests_per_game -q`

------
https://chatgpt.com/codex/tasks/task_e_68482bb010c8832b8d20f7d8813f29fe