### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENT INSTRUCTIONS
+
+## Scope
+These instructions apply to the entire repository except where overridden by a nested `AGENTS.md` file.
+
+## Repository Overview
+This project, QuestByCycle, is a Flask based web application with a Node/Vite
+frontend.  Python packages are managed via `pyproject.toml`.  Tests are located
+in the `tests/` directory and use `pytest`.  Documentation lives in `docs/`.
+
+## Coding Guidelines
+- Use **Python 3.11** features.
+- Follow PEP 8 style with 4 space indents.
+- Keep line length under **120 characters**.
+- Prefer double quotes for strings unless single quotes improve readability.
+- Document all functions and classes with docstrings.
+- Organize imports in three groups: standard library, third party, project.
+- For JavaScript/ES modules keep semicolons and prefer `const`/`let`.
+- When editing SCSS or JS, run the Vite build to ensure no compilation errors.
+
+## Testing Instructions
+1. Install dependencies with `pip install -r requirements.txt` if available
+   or `pip install -e .` (in non-package mode use `pip install flask ...`).
+2. Run the test suite from the repository root with:
+   ```bash
+   PYTHONPATH="$PWD" pytest
+   ```
+   All tests should pass. If tests fail, investigate and fix them or document why
+   the failure is expected.
+
+## Commit Guidelines
+- Make small, focused commits with descriptive messages.
+- Describe *why* a change is made, not just *what* changed.
+- Run tests before each commit.
+
+## Documentation
+Update the Markdown files in `docs/` when code changes affect user or developer
+behavior. Follow the style described in `docs/AGENTS.md`.
+
+## Frontend
+The `frontend/` directory contains modern JS that is bundled using Vite. After
+modifying any JS or SCSS, run:
+```bash
+npm install   # only once
+npm run build
+```
+Ensure the build succeeds before committing.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENT INSTRUCTIONS for /docs
+
+## Scope
+These rules apply to everything within the `docs/` directory.
+
+## Documentation Style
+- Write in Markdown using clear headings (`#`, `##`, etc.).
+- Keep lines under **120 characters**.
+- Use concise paragraphs and bulleted lists where appropriate.
+- Code samples should be fenced with triple backticks and the language name.
+- File names should remain uppercase with the `.md` extension, matching the
+  existing convention (e.g., `DEVELOPER.md`).
+
+## Content Guidelines
+- Keep documentation up to date with the codebase.
+- Explain configuration options referenced in `config.toml` or the application.
+- When adding new features, update or create documentation describing how to use
+  them from both user and developer perspectives.
+- Do not remove existing documentation unless it has become obsolete and the
+  removal is noted in the commit message.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENT INSTRUCTIONS for /frontend
+
+## Scope
+Rules in this file apply to all JavaScript and related assets in `frontend/`.
+
+## Coding Style
+- Use modern ES6+ syntax with modules.
+- Terminate statements with semicolons.
+- Prefer `const` and `let` over `var`.
+- Keep line length under **120 characters**.
+- Organize imports at the top of each file.
+
+## Build
+After modifying any file in this directory or in `app/static/scss`, run:
+```bash
+npm install    # run once if node_modules is missing
+npm run build
+```
+This generates bundled files under `app/static/dist/`.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENT INSTRUCTIONS for /tests
+
+## Scope
+These rules cover the test suite under `tests/`.
+
+## Test Guidelines
+- Tests use **pytest** exclusively. Each file should start with standard imports
+  followed by fixtures and test cases.
+- Name test files starting with `test_` and use descriptive function names.
+- Keep tests isolated; avoid network calls or external services.
+- Temporary files should use Python's `tmp_path` fixture.
+
+## Running Tests
+Execute all tests from the repository root with:
+```bash
+PYTHONPATH="$PWD" pytest
+```
+All tests should pass before committing. If failures are expected, document the
+reason in the commit message.


### PR DESCRIPTION
## Summary
- add repository-wide agent instructions
- document style and content rules for docs
- outline test requirements in tests directory
- add frontend build instructions for JS

## Testing
- `PYTHONPATH="$PWD" pytest -q` *(fails: Failed tests/test_utils.py::test_save_submission_video_invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6848307cbcc8832b9dc6788d1b0b13b5