### PR TITLE
Refactor SQLAlchemy queries

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -185,9 +185,9 @@ def create_app(config_overrides=None):
 
     @login_manager.user_loader
     def load_user(user_id):
-        from app.models import User
+        from app.models import User, db
         try:
-            return User.query.get(int(user_id))
+            return db.session.get(User, int(user_id))
         except (TypeError, ValueError):
             logger.error("Invalid user_id in session: %s", user_id)
             return None

--- a/app/activitypub_utils.py
+++ b/app/activitypub_utils.py
@@ -306,7 +306,7 @@ def inbox(username):
                 db.session.add(reply)
                 db.session.commit()
                                          
-                sub = QuestSubmission.query.get(sid)
+                sub = db.session.get(QuestSubmission, sid)
                 if sub:
                     db.session.add(Notification(
                         user_id=sub.user_id,
@@ -348,7 +348,7 @@ def inbox(username):
         if '/submissions/' in obj_id:
             try:
                 sid = int(obj_id.rsplit('/', 1)[1])
-                sub = QuestSubmission.query.get(sid)
+                sub = db.session.get(QuestSubmission, sid)
                 if sub:
                     db.session.add(Notification(
                         user_id=sub.user_id,

--- a/app/admin.py
+++ b/app/admin.py
@@ -78,7 +78,7 @@ def user_management(game_id=None):
                                                           
     selected_game = None
     if game_id:
-        selected_game = Game.query.get(game_id)
+        selected_game = db.session.get(Game, game_id)
 
                                                    
     if selected_game:
@@ -112,7 +112,7 @@ def user_management(game_id=None):
 @login_required
 @require_super_admin
 def user_details(user_id):
-    user = User.query.get(user_id)
+    user = db.session.get(User, user_id)
     if not user:
         return
 
@@ -123,7 +123,7 @@ def user_details(user_id):
 @login_required
 @require_super_admin
 def update_user(user_id):
-    user = User.query.get(user_id)
+    user = db.session.get(User, user_id)
     if not user:
         flash('User not found.', 'error')
         return redirect(url_for('admin.user_management'))
@@ -156,7 +156,7 @@ def update_user(user_id):
 def edit_user(user_id):
     logging.debug("Entered edit_user function with user_id: %s", user_id)
     
-    user = User.query.get(user_id)
+    user = db.session.get(User, user_id)
     if not user:
         logging.error("User not found with id: %s", user_id)
         flash('User not found', 'error')
@@ -255,7 +255,7 @@ def edit_user(user_id):
 @login_required
 @require_super_admin
 def delete_user(user_id):
-    user = User.query.get(user_id)
+    user = db.session.get(User, user_id)
     if not user:
         flash('User not found.', 'error')
         return redirect(url_for('admin.user_management'))

--- a/app/games.py
+++ b/app/games.py
@@ -4,8 +4,16 @@ import base64
 import qrcode
 
 from flask import (
-    Blueprint, jsonify, render_template, request, redirect, url_for, flash,
-    current_app, make_response
+    Blueprint,
+    jsonify,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    current_app,
+    make_response,
+    abort,
 )
 from flask_login import login_required, current_user
 from sqlalchemy.exc import SQLAlchemyError
@@ -150,7 +158,9 @@ def update_game(game_id):
     """
     Update an existing game's information based on the submitted form data.
     """
-    game = Game.query.get_or_404(game_id)
+    game = db.session.get(Game, game_id)
+    if not game:
+        abort(404)
     if not current_user.is_admin_for_game(game_id):
         flash('Access denied: Only assigned admins can edit this game.', 'danger')
         return redirect(url_for('main.index'))
@@ -271,7 +281,7 @@ def game_info(game_id):
     Display game information. If a 'modal' query parameter is provided,
     render a modal template; otherwise, render the full game info page.
     """
-    game_obj = Game.query.get(game_id)
+    game_obj = db.session.get(Game, game_id)
     if not game_obj:
         flash("Game details are not available.", "error")
         return redirect(url_for('main.index'))
@@ -300,7 +310,7 @@ def get_game_points(game_id):
         Quest.game_id == game_id
     ).scalar() or 0
 
-    game = Game.query.get(game_id)
+    game = db.session.get(Game, game_id)
     game_goal = game.game_goal
 
     return jsonify(total_game_points=total_game_points, game_goal=game_goal)

--- a/app/models.py
+++ b/app/models.py
@@ -200,7 +200,7 @@ class User(UserMixin, db.Model):
             user_id = payload['verify_email']
         except jwt.exceptions.InvalidTokenError:
             return None
-        return User.query.get(user_id)
+        return db.session.get(User, user_id)
 
     def generate_reset_token(self, expiration=320000):
         """Generate a JWT token for password reset."""
@@ -223,7 +223,7 @@ class User(UserMixin, db.Model):
             user_id = payload['reset_password']
         except jwt.exceptions.InvalidTokenError:
             return None
-        return User.query.get(user_id)
+        return db.session.get(User, user_id)
 
     def set_password(self, password):
         """Set the user's password."""
@@ -290,7 +290,7 @@ class User(UserMixin, db.Model):
 
     def is_admin_for_game(self, game_id):
         """Return True if the user is an admin for the given game."""
-        game = Game.query.get(game_id)
+        game = db.session.get(Game, game_id)
         return bool(game and (self in game.admins or self.is_super_admin))
 
 

--- a/app/profile.py
+++ b/app/profile.py
@@ -17,7 +17,7 @@ def _deliver_follow_activity(app, actor_url, activity, sender_id):
     with app.app_context():
         try:
 
-            sender = User.query.get(sender_id)
+            sender = db.session.get(User, sender_id)
             sender.ensure_activitypub_actor()
 
             doc = requests.get(actor_url, timeout=REQUEST_TIMEOUT).json()
@@ -111,7 +111,11 @@ def post_reply(user_id, message_id):
         current_user.id == user.id or
         current_user.id == message.author_id or
         current_user.id == message.user_id or
-        (message.parent_id and current_user.id == ProfileWallMessage.query.get(message.parent_id).author_id)
+        (
+            message.parent_id
+            and current_user.id
+            == db.session.get(ProfileWallMessage, message.parent_id).author_id
+        )
     ):
         return jsonify({'error': 'You are not authorized to reply to messages on this profile.'}), 403
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -197,7 +197,7 @@ def generate_smoggy_images(image_path, game_id):
 
 def update_user_score(user_id):
     try:
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
         if not user:
             return False
 
@@ -389,7 +389,7 @@ def save_sponsor_logo(image_file, old_filename=None):
 
 def can_complete_quest(user_id, quest_id):
     now = datetime.now(UTC)
-    quest = Quest.query.get(quest_id)
+    quest = db.session.get(Quest, quest_id)
     
     if not quest:
         return False, None                        
@@ -425,7 +425,7 @@ def can_complete_quest(user_id, quest_id):
 
 def getLastRelevantCompletionTime(user_id, quest_id):
     now = datetime.now(UTC)
-    quest = Quest.query.get(quest_id)
+    quest = db.session.get(Quest, quest_id)
     
     if not quest:
         return None                        
@@ -452,8 +452,8 @@ def check_and_award_badges(user_id, quest_id, game_id):
         every quest in that category for the specified game.
     All awards and associated shoutboard messages are tied to the given game_id.
     """
-    user = User.query.get(user_id)
-    quest = Quest.query.get(quest_id)
+    user = db.session.get(User, user_id)
+    quest = db.session.get(Quest, quest_id)
     user_quest = UserQuest.query.filter_by(user_id=user_id, quest_id=quest_id).first()
     if not user_quest:
         return
@@ -559,7 +559,7 @@ def check_and_revoke_badges(user_id, game_id=None):
         of every quest in that badge’s category for the specified game.
     When revoking a badge, its associated shoutboard award message is deleted.
     """
-    user = User.query.get(user_id)
+    user = db.session.get(User, user_id)
     if not user:
         return
 
@@ -859,7 +859,7 @@ def generate_demo_game():
         leaderboard_image="leaderboard_image.png"                                                     
     )
     db.session.add(demo_game)
-    admin_user = User.query.get(1)
+    admin_user = db.session.get(User, 1)
     if admin_user:
         demo_game.admins.append(admin_user)
     db.session.commit()
@@ -955,7 +955,7 @@ def log_user_ip(user):
 
 
 def get_game_badges(game_id):
-    game = Game.query.get(game_id)
+    game = db.session.get(Game, game_id)
     if not game:
         return []
 
@@ -984,7 +984,7 @@ def send_social_media_liaison_email(
     try:
                                                               
                                                           
-        game = Game.query.get(game_id)
+        game = db.session.get(Game, game_id)
     except Exception as e:
         current_app.logger.error(
             f"Database error while fetching Game id={game_id}: {e}"


### PR DESCRIPTION
## Summary
- migrate to new SQLAlchemy 2.x `Session.get` API
- add abort handling where `get_or_404` was replaced
- update badge and game imports to include `abort`

## Testing
- `PYTHONPATH="$PWD" pytest -q` *(fails: test_save_submission_video_invalid - ffmpeg not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68492db19adc832b94024a14ec135d46