### PR TITLE
Fix cookie domain handling

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -314,8 +314,11 @@ def login():
 
                                            
     if current_user.is_authenticated:
-                                                                               
-        return redirect(next_page or url_for('main.index'))
+        if next_page and _is_safe_url(next_page):
+            target = next_page
+        else:
+            target = url_for('main.index', show_login=0, next=next_page)
+        return redirect(target)
 
                                                           
     if request.method == 'GET':

--- a/app/config.py
+++ b/app/config.py
@@ -52,6 +52,15 @@ def _get_env_integer(key: str, default: int):
     except ValueError:
         return default
 
+def _get_env_nullable(key: str, default=None):
+    """Retrieve an environment variable but return ``None`` for falsey values."""
+    val = os.getenv(key)
+    if val is None:
+        val = default
+    if val in (False, "", "false", "False", None):
+        return None
+    return val
+
                                                                                
                                                                        
                                                                                
@@ -116,7 +125,7 @@ def load_config():
                 "SESSION_COOKIE_SAMESITE",
                 _toml_config["encryption"]["SESSION_COOKIE_SAMESITE"]
             ),
-            "SESSION_COOKIE_DOMAIN": _get_env(
+            "SESSION_COOKIE_DOMAIN": _get_env_nullable(
                 "SESSION_COOKIE_DOMAIN",
                 _toml_config["encryption"]["SESSION_COOKIE_DOMAIN"]
             ),

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -301,6 +301,8 @@ Before deploying to production, ensure the following settings in `config.toml`:
 
 - `DEBUG = false`
 - `SESSION_COOKIE_SECURE = true`
+- `SESSION_COOKIE_DOMAIN` should match your production domain or be left blank to
+  use the request host.
 - `SQLALCHEMY_DATABASE_URI` is set to the production database URL.
 - `SECRET_KEY` is set to a secure value.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,14 @@
+import os
+from app import create_app
+
+
+def test_session_cookie_domain_defaults(monkeypatch):
+    monkeypatch.delenv("SESSION_COOKIE_DOMAIN", raising=False)
+    app = create_app({"TESTING": True})
+    assert app.config["SESSION_COOKIE_DOMAIN"] is None
+
+
+def test_session_cookie_domain_env(monkeypatch):
+    monkeypatch.setenv("SESSION_COOKIE_DOMAIN", "example.com")
+    app = create_app({"TESTING": True})
+    assert app.config["SESSION_COOKIE_DOMAIN"] == "example.com"


### PR DESCRIPTION
## Summary
- avoid invalid session cookie domain
- guard login redirection against unsafe `next` values
- document `SESSION_COOKIE_DOMAIN` option
- test config cookie domain behaviour

## Testing
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493510c1c8832b9c020b3b15725c66