### PR TITLE
Add CSRF troubleshooting tip

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -293,6 +293,10 @@ Tests are crucial for maintaining the integrity of the codebase. To run tests:
 
 To enable debugging, update the `config.toml` file to set `DEBUG = true`. This will enable Flask's debugger, providing detailed error messages and an interactive debugger in the browser.
 
+If login requests fail with a "CSRF session token is missing" message, the session cookie was not
+sent. Ensure `SECRET_KEY` is defined and access the site using the host specified by
+`LOCAL_DOMAIN` (typically `localhost:5000`).
+
 ## Deployment
 
 ### Production Configuration


### PR DESCRIPTION
## Summary
- document how to resolve missing CSRF session token errors

## Testing
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684936a2b7f0832b8873c8a020bbbae7