### PR TITLE
Fix registration email verification

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -537,7 +537,16 @@ def register():
 
                                      
     create_activitypub_actor(user)
-    _auto_verify_and_login(user)
+
+    mail_server = current_app.config.get("MAIL_SERVER")
+    if mail_server:
+        _send_verification_email(user)
+        flash(
+            "Registration successful! Please verify your email before logging in.",
+            "info",
+        )
+    else:
+        _auto_verify_and_login(user)
                                                                    
                                               
                              

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -30,7 +30,7 @@ Welcome to our Ultimate Challenge and Reward Platform! This guide will help you 
 2. **Fill in Your Details**: Enter your username, email, and password.
 3. **Agree to Terms and Conditions**: Check the box to agree to the terms and conditions.
 4. **Submit**: Click on "Create Account" to complete the sign-up process.
-5. **Email Verification**: Check your email for a verification link and click on it to verify your account.
+5. **Email Verification**: If the site is configured with email support, check your inbox for a verification link and click it before you can log in. On instances without email configured you will be logged in automatically.
 
 **Log In**:
 1. **Navigate to the Log-In Page**: Click on the "Log In" button on the homepage.


### PR DESCRIPTION
## Summary
- ensure registrations only auto-verify when email isn't configured
- clarify sign-up instructions about email verification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494eb202c8832b8ac19fcf8b3edd3c