### PR TITLE
Cleanup global JS exports

### DIFF
--- a/frontend/layout.js
+++ b/frontend/layout.js
@@ -1,5 +1,6 @@
 
 import logger from './logger.js';
+import { openModal } from './modules/modal_common.js';
 
 export function initLayout() {
   if ('serviceWorker' in navigator) {
@@ -131,11 +132,7 @@ export function initLayout() {
 export function handleGameSelection(opt) {
   const val = opt.value;
   if (val === 'join_custom_game') {
-    if (typeof window.openModal === 'function') {
-      window.openModal('joinCustomGameModal');
-    } else {
-      window.location.href = '/?show_join_custom=1';
-    }
+    openModal('joinCustomGameModal');
   } else {
     window.location.href = val;
   }

--- a/frontend/modules/modal_common.js
+++ b/frontend/modules/modal_common.js
@@ -443,21 +443,10 @@ document.addEventListener('click', e => {
 
 // on DOMContentLoaded, hoist *all* static .modal up under <body>
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.modal').forEach(m => {
+  document.querySelectorAll('.modal').forEach((m) => {
     if (m.parentNode !== document.body) {
       document.body.appendChild(m);
     }
   });
 });
-// Expose globally for inline handlers
-window.openModal = openModal;
-window.closeModal = closeModal;
-window.openLoginModalWithOptions = openLoginModalWithOptions;
-window.openRegisterModalWithOptions = openRegisterModalWithOptions;
-window.openLoginModalWithGame = openLoginModalWithGame;
-window.openForgotPasswordModal = openForgotPasswordModal;
-window.openResetPasswordModal = openResetPasswordModal;
-window.fetchAndShowModal = fetchAndShowModal;
-window.submitFormJson = submitFormJson;
-window.resetModalContent = resetModalContent;
 

--- a/frontend/modules/submission_detail_modal.js
+++ b/frontend/modules/submission_detail_modal.js
@@ -370,7 +370,5 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.disabled      = true;
     if (replyLimitMessage) replyLimitMessage.style.display = 'block';
   }
-  // Provide global access for existing inline handlers
-  window.showSubmissionDetail = showSubmissionDetail;
 });
 


### PR DESCRIPTION
## Summary
- stop exposing modal helpers on `window`
- load modal helper in layout
- remove obsolete global function from submission modal

## Testing
- `npm run build`
- `PYTHONPATH="$PWD" pytest -q` *(fails: many tests failing due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849563c0780832b96426c1291cd5cdf