### PR TITLE
Remove unused config and use current_app config in utils

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -52,20 +52,12 @@ from app.utils import (
     sanitize_html,
     correct_image_orientation,
 )
-from .config import load_config
 
                    
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-                  
 main_bp = Blueprint('main', __name__)
-
-
-                    
-config = load_config()
-
-
 
 
 def get_datetime(activity):

--- a/app/utils.py
+++ b/app/utils.py
@@ -223,7 +223,7 @@ def update_user_score(user_id):
 
 
 def save_profile_picture(profile_picture_file, old_filename=None):
-    uploads = current_app.config['main']['UPLOAD_FOLDER']
+    uploads = current_app.config['UPLOAD_FOLDER']
     return save_image_file(profile_picture_file, uploads, old_filename=old_filename)
 
 
@@ -242,7 +242,7 @@ def save_badge_image(image_file):
 
 def save_bicycle_picture(bicycle_picture_file, old_filename=None):
     subdir = os.path.join(
-        current_app.config['main']['UPLOAD_FOLDER'], 'bicycle_pictures'
+        current_app.config['UPLOAD_FOLDER'], 'bicycle_pictures'
     )
     return save_image_file(
         bicycle_picture_file,


### PR DESCRIPTION
## Summary
- clean up unused `config` variable in `main.py`
- read upload directories directly from `current_app.config`

## Testing
- `pip install flask werkzeug flask-wtf flask-sqlalchemy flask-login sqlalchemy psycopg[binary] wtforms email-validator cryptography pyjwt gunicorn apscheduler qrcode[pil] openai tomli pywebpush pytest python-dotenv rsa html-sanitizer requests-oauthlib`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684960c258a0832b80964b0d5215f1bb