### PR TITLE
Apply admin decorators consistently

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -310,10 +310,8 @@ def edit_sponsor(sponsor_id):
 
 @admin_bp.route('/sponsors/delete/<int:sponsor_id>', methods=['POST'])
 @login_required
+@require_admin
 def delete_sponsor(sponsor_id):
-    if not current_user.is_admin:
-        flash('Access denied.', 'danger')
-        return redirect(url_for('auth.login'))
 
     game_id = request.form.get('game_id', type=int)                                       
 
@@ -327,7 +325,7 @@ def delete_sponsor(sponsor_id):
         flash(f'Error occurred: {e}', 'danger')
     
                                                            
-    return redirect(url_for('admin.manage_sponsors', game_id=game_id))  
+    return redirect(url_for('admin.manage_sponsors', game_id=game_id))
 
 
 
@@ -343,10 +341,8 @@ def sponsors():
 
 @admin_bp.route('/admin/sponsors', methods=['GET', 'POST'])
 @login_required
+@require_admin
 def manage_sponsors():
-    if not current_user.is_admin:
-        flash('Access denied.', 'danger')
-        return redirect(url_for('auth.login'))
 
     game_id = request.args.get('game_id', type=int)
     if request.method == 'POST':

--- a/app/badges.py
+++ b/app/badges.py
@@ -17,6 +17,7 @@ from flask import (
     abort,
 )
 from flask_login import login_required, current_user
+from app.decorators import require_admin
 from .forms import BadgeForm
                                                           
 from .utils import save_badge_image
@@ -37,10 +38,8 @@ def allowed_file(filename):
 
 @badges_bp.route('/create', methods=['GET', 'POST'])
 @login_required
+@require_admin
 def create_badge():
-    if not current_user.is_admin:
-        flash('Access denied: Only administrators can manage badges.', 'danger')
-        return redirect(url_for('main.index'))
 
                                               
     quest_categories = db.session.query(Quest.category).filter(Quest.category.isnot(None)).distinct().all()
@@ -139,10 +138,8 @@ def get_badges():
 
 @badges_bp.route('/manage_badges', methods=['GET', 'POST'])
 @login_required
+@require_admin
 def manage_badges():
-    if not current_user.is_admin:
-        flash('Access denied: Only administrators can manage badges.', 'danger')
-        return redirect(url_for('main.index'))
 
                                               
     quest_categories = db.session.query(Quest.category).filter(Quest.category.isnot(None)).distinct().all()
@@ -219,9 +216,8 @@ def update_badge(badge_id):
 
 @badges_bp.route('/delete/<int:badge_id>', methods=['DELETE'])
 @login_required
+@require_admin
 def delete_badge(badge_id):
-    if not current_user.is_admin:
-        return jsonify({'success': False, 'message': 'Permission denied'}), 403
     badge = db.session.get(Badge, badge_id)
     if not badge:
         return jsonify({'success': False, 'message': 'Badge not found'}), 404
@@ -244,9 +240,8 @@ def get_quest_categories():
 
 @badges_bp.route('/upload_images', methods=['POST'])
 @login_required
+@require_admin
 def upload_images():
-    if not current_user.is_admin:
-        return jsonify({'success': False, 'message': 'Unauthorized access'}), 403
 
     uploaded_files = request.files.getlist('file')
     images_folder = os.path.join(current_app.root_path, 'static', 'images', 'badge_images')
@@ -274,10 +269,8 @@ def upload_images():
 
 @badges_bp.route('/bulk_upload', methods=['POST'])
 @login_required
+@require_admin
 def bulk_upload():
-    if not current_user.is_admin:
-        flash('Access denied: Only administrators can manage badges.', 'danger')
-        return redirect(url_for('main.index'))
 
     csv_file = request.files.get('csv_file')
     image_files = request.files.getlist('image_files')

--- a/app/games.py
+++ b/app/games.py
@@ -16,6 +16,7 @@ from flask import (
     abort,
 )
 from flask_login import login_required, current_user
+from app.decorators import require_admin
 from sqlalchemy.exc import SQLAlchemyError
 from app.models import db, user_games
 from app.models.game import Game
@@ -207,11 +208,9 @@ def update_game(game_id):
 
 @games_bp.route('/send_liaison_email/<int:game_id>', methods=['POST'])
 @login_required
+@require_admin
 def send_liaison_email(game_id):
     """Manually trigger sending of liaison emails for a game."""
-    if not current_user.is_admin:
-        flash('Access denied: Only administrators can send liaison emails.', 'danger')
-        return redirect(url_for('main.index'))
 
     if send_social_media_liaison_email(game_id, fallback_to_last=True):
         flash('Liaison email sent successfully.', 'success')
@@ -249,14 +248,12 @@ def register_game(game_id):
 
 @games_bp.route('/delete_game/<int:game_id>', methods=['POST'])
 @login_required
+@require_admin
 def delete_game(game_id):
     """
     Delete a game. Only administrators are allowed to delete games.
     Prior to deletion, ensure that users referencing the game have their selected_game_id set to NULL.
     """
-    if not current_user.is_admin:
-        flash('Access denied: Only administrators can delete games.', 'danger')
-        return redirect(url_for('main.index'))
 
     game = Game.query.get_or_404(game_id)
     

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 from flask_login import current_user, login_required
+from app.decorators import require_admin
 from flask_wtf.csrf import generate_csrf
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload
@@ -788,14 +789,12 @@ def edit_bike(user_id):
 
 @main_bp.route('/pin_message/<int:game_id>/<int:message_id>', methods=['POST'])
 @login_required
+@require_admin
 def pin_message(game_id, message_id):
     """
     Toggle the pin status of a shout board message.
     """
     message = ShoutBoardMessage.query.get_or_404(message_id)
-    if not current_user.is_admin:
-        flash('You do not have permission to perform this action.', 'danger')
-        return redirect(url_for('main.index'))
     message.is_pinned = not message.is_pinned
     db.session.commit()
     flash('Message pin status updated.', 'success')

--- a/app/quests.py
+++ b/app/quests.py
@@ -25,6 +25,7 @@ from flask import (
     abort
 )
 from flask_login import current_user, login_required
+from app.decorators import require_admin
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.utils import secure_filename
 from app.forms import PhotoForm, QuestForm
@@ -336,6 +337,7 @@ def submit_quest(quest_id):
 
 @quests_bp.route("/quest/<int:quest_id>/update", methods=["POST"])
 @login_required
+@require_admin
 def update_quest(quest_id):
     """
     Update quest details. Only accessible to administrators.
@@ -343,8 +345,6 @@ def update_quest(quest_id):
     Args:
         quest_id (int): The ID of the quest.
     """
-    if not current_user.is_admin:
-        return jsonify({"success": False, "message": "Permission denied"}), 403
 
     quest = Quest.query.get_or_404(quest_id)
     data = request.get_json()


### PR DESCRIPTION
## Summary
- refactor admin views to use `require_admin` decorator
- enforce admin permissions in badges endpoints
- clean up game and main routes with decorators
- gate quest update route with admin decorator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496e4f5704832b812e003f71b75d2b