### PR TITLE
Remove jQuery references

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -64,7 +64,6 @@
   <meta name="placeholder-image" content="{{ placeholder_image }}">
 
   <!-- JavaScript -->
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.9.0/highlight.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -266,7 +266,7 @@ Our platform leverages AI to generate new quests for users. This functionality i
 
 ### CSS and JavaScript
 
-Third-party libraries (Bootstrap, jQuery, KaTeX, Font Awesome, and Highlight.js) are now loaded directly from public CDNs.
+Third-party libraries (Bootstrap, KaTeX, Font Awesome, and Highlight.js) are now loaded directly from public CDNs.
 Only project specific assets remain under `app/static`.
 
 ### Images and Videos

--- a/docs/default.NGINX
+++ b/docs/default.NGINX
@@ -25,7 +25,7 @@ server {
     # Content Security Policy
     add_header Content-Security-Policy "
         default-src 'self';
-        script-src 'self' 'unsafe-inline' https://code.jquery.com https://cdnjs.cloudflare.com https://stackpath.bootstrapcdn.com https://cdn.jsdelivr.net https://code.jquery.com https://cdnjs.cloudflare.com https://www.googletagmanager.com;
+        script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://stackpath.bootstrapcdn.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.googletagmanager.com;
         style-src 'self' 'unsafe-inline' https://stackpath.bootstrapcdn.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com;
         img-src 'self' data:;
         font-src 'self' data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com;


### PR DESCRIPTION
## Summary
- drop jQuery include from the main layout
- update CDN library list in DEVELOPER docs
- clean up CSP example to remove code.jquery.com

## Testing
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684971a79fdc832b8a900257ee34fc76