### PR TITLE
Fix logout clears session

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -460,6 +460,7 @@ def logout():
     Log out the current user.
     """
     logout_user()
+    session.clear()
     flash('Logged out successfully.', 'success')
     return redirect(url_for('main.index'))
 

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -1,0 +1,45 @@
+import pytest
+from datetime import datetime, timezone
+from app import create_app, db
+from app.models.user import User
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "MAIL_SERVER": None,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.drop_all()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+@pytest.fixture
+def user(app):
+    u = User(username="test", email="test@example.com", email_verified=True, license_agreed=True)
+    u.set_password("secret")
+    u.created_at = datetime.now(timezone.utc)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+def login(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+
+def test_logout_clears_session(client, user):
+    login(client, user)
+    resp = client.get("/auth/logout", follow_redirects=False)
+    assert resp.status_code == 302
+    with client.session_transaction() as sess:
+        assert "_user_id" not in sess


### PR DESCRIPTION
## Summary
- clear session data during logout to ensure the user is fully signed out
- add regression test verifying session is cleared

## Testing
- `pip install flask werkzeug flask-wtf flask-sqlalchemy flask-login sqlalchemy psycopg[binary] wtforms email-validator cryptography pyjwt gunicorn apscheduler qrcode[pil] openai pywebpush pytest python-dotenv rsa html-sanitizer requests-oauthlib redis rq psycopg2-binary`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b576bc64832b819dd3090502235e