### PR TITLE
Add infrastructure docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ This project relies on a variety of open source libraries. The badges below link
 [![Gunicorn](https://img.shields.io/badge/Gunicorn-872729?style=for-the-badge&logo=gunicorn&logoColor=white)](https://github.com/benoitc/gunicorn)
 [![APScheduler](https://img.shields.io/badge/APScheduler-555?style=for-the-badge&logo=python&logoColor=white)](https://github.com/agronholm/apscheduler)
 
+For automated provisioning details see [docs/INFRASTRUCTURE.md](docs/INFRASTRUCTURE.md).
+
 ### Utility Libraries
 
 [![qrcode](https://img.shields.io/badge/qrcode-555?style=for-the-badge&logo=python&logoColor=white)](https://github.com/lincolnloop/python-qrcode)

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -1,0 +1,30 @@
+# INFRASTRUCTURE
+
+This guide explains how to provision and configure the production server using Terraform and Ansible.
+
+## Terraform Setup
+
+1. Install [Terraform](https://www.terraform.io/downloads) and the Google Cloud CLI.
+2. Edit `infra/terraform/main.tf` with your project ID and service account email.
+3. Initialize the working directory:
+   ```bash
+   cd infra/terraform
+   terraform init
+   ```
+4. Apply the configuration to create the VM and firewall rules:
+   ```bash
+   terraform apply
+   ```
+   The public IP output will be used by Ansible.
+
+## Ansible Provisioning
+
+1. Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/index.html).
+2. Export the environment variables referenced in `infra/ansible/group_vars/all/vault.yml`.
+3. Update `infra/ansible/inventory.yml` with the VM IP and your OS login user.
+4. Run the playbook:
+   ```bash
+   cd infra/ansible
+   ansible-playbook -i inventory.yml site.yml
+   ```
+   This installs dependencies, sets up PostgreSQL, and configures Gunicorn and Nginx.


### PR DESCRIPTION
## Summary
- document how to provision infrastructure with Terraform and Ansible
- link to new documentation from README

## Testing
- `poetry install`
- `PYTHONPATH="$PWD" pytest`

------
https://chatgpt.com/codex/tasks/task_e_684ac2c78830832b96d97e32a9d43a5a