### PR TITLE
Fix leaderboard participant count

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -555,7 +555,7 @@ def leaderboard_partial():
     ).filter(Quest.game_id == selected_game_id
     ).scalar() or 0
 
-    num_participants = game.participants.count()
+    num_participants = len(game.participants)
     num_quests = Quest.query.filter_by(game_id=selected_game_id).count()
     avg_points = round(total_game_points / num_participants, 2) if num_participants else 0
     secondary_stats = [


### PR DESCRIPTION
## Summary
- use `len(game.participants)` instead of the list `.count()` method when computing leaderboard stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de00209b4832b804c9d0eb780d0d5