### PR TITLE
Allow per-game calendar URLs

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -194,6 +194,7 @@ class GameForm(FlaskForm):
     facebook_page_id = StringField("Facebook Page ID")
     instagram_user_id = StringField("Instagram User ID", validators=[Optional()])
     instagram_access_token = StringField("Instagram Access Token", validators=[Optional()])
+    calendar_url = StringField("Calendar URL", validators=[Optional(), URL()])
     custom_game_code = StringField("Custom Game Code", validators=[Optional()])
     is_public = BooleanField("Public Game", default=True)
     allow_joins = BooleanField("Allow Joining", default=True)

--- a/app/games.py
+++ b/app/games.py
@@ -47,6 +47,7 @@ def serialize_game(game):
         "game_goal": game.game_goal,
         "is_public": game.is_public,
         "allow_joins": game.allow_joins,
+        "calendar_url": game.calendar_url,
     }
 
 
@@ -70,6 +71,7 @@ def populate_game_from_form(game, form):
         "facebook_page_id",
         "instagram_user_id",
         "instagram_access_token",
+        "calendar_url",
         "social_media_liaison_email",
     ]
 

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -57,6 +57,7 @@ class Game(db.Model):
     facebook_page_id = db.Column(db.String(500), nullable=True)
     instagram_user_id = db.Column(db.String(500), nullable=True)
     instagram_access_token = db.Column(db.String(500), nullable=True)
+    calendar_url = db.Column(db.String(500), nullable=True)
     custom_game_code = db.Column(db.String(20), unique=True, nullable=True)
     is_public = db.Column(db.Boolean, default=True)
     allow_joins = db.Column(db.Boolean, default=True)

--- a/app/templates/create_game.html
+++ b/app/templates/create_game.html
@@ -165,6 +165,11 @@
             <label for="instagram_user_id">Instagram User ID</label>
             {{ form.instagram_user_id(class_="form-control", id="instagram_user_id") }}
         </div>
+        <div class="form-group">
+            <label for="calendar_url">Calendar URL</label>
+            {{ form.calendar_url(class_="form-control", id="calendar_url") }}
+            <small class="form-text text-muted">Embed link for the game's calendar.</small>
+        </div>
         <button type="submit" class="btn btn-primary">Create Game</button>
     </form>
 </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -88,7 +88,9 @@
                                     <!-- Tab Navigation -->  
                                     <div class="wh-tab-navigation">
                                         <button class="wh-tab-button active" data-wh-tab="recent-activity">Recent Activity</button>
-                                        <button class="wh-tab-button"        data-wh-tab="google-calendar">Calendar</button>
+                                        {% if game.calendar_url %}
+                                        <button class="wh-tab-button" data-wh-tab="google-calendar">Calendar</button>
+                                        {% endif %}
                                     </div>
                                 </div>  
                                 <!-- Recent Activity Tab -->  
@@ -198,13 +200,15 @@
                                         </div>
                                     </div>
                                 </div>
-                                <!-- Google Calendar Tab -->  
-                                <div class="wh-tab-content" id="wh-google-calendar-tab">  
-                                    <div class="calendar-container">  
-                                        <iframe src="https://calendar.google.com/calendar/embed?src=7641f437a33113e72a9539618fefdb4275bbdc56bcd8090e8598383398dd1bab@group.calendar.google.com&ctz=America%2FLos_Angeles"
+                                {% if game.calendar_url %}
+                                <!-- Google Calendar Tab -->
+                                <div class="wh-tab-content" id="wh-google-calendar-tab">
+                                    <div class="calendar-container">
+                                        <iframe src="{{ game.calendar_url }}"
                                                 class="border-0" width="100%" height="350" frameborder="0" scrolling="no"></iframe>
-                                    </div>  
-                                </div>  
+                                    </div>
+                                </div>
+                                {% endif %}
                             </div>
                         </div>
                     </div>

--- a/app/templates/update_game.html
+++ b/app/templates/update_game.html
@@ -126,6 +126,11 @@
             <label for="instagram_user_id">Instagram User ID</label>
             {{ form.instagram_user_id(class_="form-control", id="instagram_user_id") }}
         </div>
+        <div class="form-group">
+            <label for="calendar_url">Calendar URL</label>
+            {{ form.calendar_url(class_="form-control", id="calendar_url") }}
+            <small class="form-text text-muted">Embed link for the game's calendar.</small>
+        </div>
         <button type="submit" class="btn btn-primary">Update Game</button>
     </form>
     <form method="POST" action="{{ url_for('games.send_liaison_email', game_id=game_id) }}" class="mt-3">

--- a/docs/NEWGAME.md
+++ b/docs/NEWGAME.md
@@ -87,6 +87,11 @@ You will see a form with the following fields. Fill them out as described:
     - **Interaction**: Useful for private or exclusive games where you want to control who can join.
     - **Example**: "SUMMER2024".
 
+13. **Calendar URL**:
+    - **Purpose**: Optional link to an external calendar for the game.
+    - **Interaction**: When provided, participants see a Calendar tab with the embedded calendar.
+    - **Example**: `https://calendar.google.com/calendar/embed?src=your_calendar_id&ctz=America/Los_Angeles`.
+
 ### Step 3: Social Media Integration
 
 Fill in the social media integration fields if your game will use Twitter and Facebook. These fields help automate posts and updates related to the game, enhancing engagement and visibility. If these fields are left blank. They will not auto upload to the various social media platform. There are no repercusions.


### PR DESCRIPTION
## Summary
- add calendar_url field to Game model and form
- populate and serialize calendar_url
- show calendar field on create/update game templates
- conditionally show calendar tab on the index page
- document the calendar URL field

## Testing
- `pip install flask==3.1.1 werkzeug==3.1.3 flask-wtf==1.2.2 flask-sqlalchemy==3.1.1 flask-login==0.6.3 sqlalchemy==2.0.41 wtforms==3.2.1 email-validator==2.2.0 cryptography==45.0.2 pyjwt==2.10.1 gunicorn==23.0.0 apscheduler==3.11.0 qrcode[pil]==8.2 openai==1.82.0 pywebpush==1.14.0 python-dotenv==1.1.0 rsa==4.9.1 html-sanitizer==2.5.0 requests-oauthlib==2.0.0 redis==5.0.4 rq==2.3.3 psycopg2-binary==2.9.10 google-cloud-storage==2.16.0`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7f5017bc832bbc7ad2b9d2b67a44