### PR TITLE
Limit calendar sync range and clarify docs

### DIFF
--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -47,13 +47,15 @@ def sync_google_calendar_events() -> None:
             path, scopes=["https://www.googleapis.com/auth/calendar"]
         )
         service = build("calendar", "v3", credentials=creds, cache_discovery=False)
-        start_time = (game.last_calendar_sync or now - timedelta(days=7)).isoformat()
+        start_time = now.isoformat()
+        end_time = (now + timedelta(days=14)).isoformat()
         try:
             events = (
                 service.events()
                 .list(
                     calendarId=calendar_id,
                     timeMin=start_time,
+                    timeMax=end_time,
                     singleEvents=True,
                     orderBy="startTime",
                 )

--- a/docs/NEWGAME.md
+++ b/docs/NEWGAME.md
@@ -94,6 +94,7 @@ You will see a form with the following fields. Fill them out as described:
 14. **Calendar Service JSON Path**:
     - **Purpose**: Path to a Google service account JSON file for syncing calendar events.
     - **Interaction**: When set, new events create quests automatically every 15 minutes.
+      Only events scheduled within the next two weeks are imported; past events are ignored.
     - **Example**: `/home/user/service.json`.
 
 ### Step 3: Social Media Integration


### PR DESCRIPTION
## Summary
- fetch upcoming Google Calendar events only for the next two weeks
- document the rolling two‑week import window

## Testing
- `pip install flask==3.1.1 werkzeug==3.1.3 flask-wtf==1.2.2 flask-sqlalchemy==3.1.1 flask-login==0.6.3 sqlalchemy==2.0.41 psycopg[binary]==3.2.9 wtforms==3.2.1 email-validator==2.2.0 cryptography==45.0.2 pyjwt==2.10.1 gunicorn==23.0.0 apscheduler==3.11.0 qrcode[pil]==8.2 openai==1.82.0 pywebpush==1.14.0 pytest==8.3.5 python-dotenv==1.1.0 rsa==4.9.1 html-sanitizer==2.5.0 requests-oauthlib==2.0.0 redis==5.0.4 rq==2.3.3 psycopg2-binary==2.9.10 google-cloud-storage==2.16.0 google-api-python-client==2.126.0`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2fa208a0832b95b0157ca728d72c