### PR TITLE
Fix logging handler for application

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -58,8 +58,7 @@ from app.utils import sanitize_html
 from .config import load_config, AppConfig
 from app.tasks import enqueue_email
 
-                   
-logging.basicConfig(level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
 
 main_bp = Blueprint('main', __name__)


### PR DESCRIPTION
## Summary
- remove redundant `logging.basicConfig` from `app/main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3454f9d4832b80e9dea15a022726