### PR TITLE
Fix log file configuration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -48,13 +48,16 @@ csrf = CSRFProtect()
 if not os.path.exists("logs"):
     os.mkdir("logs")
 
+log_level = logging.DEBUG if os.getenv("FLASK_DEBUG") or os.getenv("DEBUG") else logging.INFO
+
 logging.basicConfig(
-    level=logging.INFO,
+    level=log_level,
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
         RotatingFileHandler("logs/application.log", maxBytes=10240, backupCount=10),
         logging.StreamHandler(),
     ],
+    force=True,
 )
 logger = logging.getLogger(__name__)
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -304,6 +304,9 @@ sent. Ensure `SECRET_KEY` is defined and access the site using the host specifie
 
 When `DEBUG=true`, JavaScript helpers skip sending CSRF tokens to simplify local testing.
 
+Log messages are saved to `logs/application.log`. Debug messages only appear
+when the application runs with `DEBUG=true` or `flask run --debug`.
+
 ## Deployment
 
 ### Production Configuration


### PR DESCRIPTION
## Summary
- ensure logging.basicConfig runs with `force=True`
- set logging level to DEBUG when FLASK_DEBUG or DEBUG is set
- document logging location in DEVELOPER.md

## Testing
- `pip install flask werkzeug flask-wtf flask-sqlalchemy flask-login sqlalchemy psycopg[binary] wtforms email-validator cryptography pyjwt gunicorn apscheduler qrcode[pil] openai pywebpush pytest python-dotenv rsa html-sanitizer requests-oauthlib redis rq psycopg2-binary google-cloud-storage google-api-python-client`
- `PYTHONPATH="$PWD" pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f3454f9d4832b80e9dea15a022726