### PR TITLE
Improve calendar quest display and event links

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -340,7 +340,23 @@
                     </thead>
                     <tbody>
                         {% set prev_date = None %}
+                        {% set shown_upcoming = false %}
+                        {% set shown_past = false %}
                         {% for quest in calendar_quests %}
+                        {% set is_past = quest.calendar_event_start and quest.calendar_event_start < now %}
+                        {% if not is_past and not shown_upcoming %}
+                        <tr class="table-primary">
+                            <td colspan="4">Upcoming</td>
+                        </tr>
+                        {% set shown_upcoming = true %}
+                        {% endif %}
+                        {% if is_past and not shown_past %}
+                        <tr class="table-primary">
+                            <td colspan="4">Past</td>
+                        </tr>
+                        {% set prev_date = None %}
+                        {% set shown_past = true %}
+                        {% endif %}
                         {% set qdate = quest.calendar_event_start.date() if quest.calendar_event_start else None %}
                         {% if qdate != prev_date %}
                         <tr class="table-secondary">

--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -100,7 +100,7 @@ def sync_google_calendar_events() -> None:
             db.session.add(quest)
             db.session.flush()
             quest_url = f"https://questbycycle.org/?quest_shortcut={quest.id}"
-            new_desc = f"View Quest: {quest_url}\n{ev.get('description', '')}"
+            new_desc = f"<a href=\"{quest_url}\">View Quest</a>\n{ev.get('description', '')}"
             try:
                 service.events().patch(
                     calendarId=calendar_id,


### PR DESCRIPTION
## Summary
- separate upcoming and past calendar quests in the UI
- add hyperlink back to quest when updating calendar events

## Testing
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4aa92204832bbcc987159fd4e4a0