### PR TITLE
Improve calendar quest layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For automated provisioning details see [docs/INFRASTRUCTURE.md](docs/INFRASTRUCT
 - **PWA/TWA Support:** Service worker and offline page. See [docs/PWA.md](docs/PWA.md) for configuration.
 - **Push Notifications:** Optional Web Push support keeps users informed even when the site is closed. See [docs/PUSH_NOTIFICATIONS.md](docs/PUSH_NOTIFICATIONS.md) for setup.
 - **Calendar Sync:** Link a Google Calendar to auto-create quests from events.
-- **Calendar Quest View:** Upcoming calendar quests are grouped by date, with past events moved to the bottom.
+- **Calendar Quest View:** Upcoming and past calendar quests are shown in separate tables for clarity.
 
 ## Getting Started
 

--- a/app/main.py
+++ b/app/main.py
@@ -351,6 +351,15 @@ def index(game_id, quest_id, user_id):
     quests, activities = _prepare_quests(game, user_id, user_quests, now)
     calendar_quests = [q for q in quests if getattr(q, 'from_calendar', False)]
     calendar_quests = _sort_calendar_quests(calendar_quests, now)
+    def _is_past_event(q):
+        if not q.calendar_event_start:
+            return False
+        aware = q.calendar_event_start if q.calendar_event_start.tzinfo else q.calendar_event_start.replace(tzinfo=UTC)
+        return aware < now
+
+    upcoming_calendar_quests = [q for q in calendar_quests if not _is_past_event(q)]
+    past_calendar_quests = [q for q in calendar_quests if _is_past_event(q)]
+
     quests = [q for q in quests if not getattr(q, 'from_calendar', False)]
     categories = sorted({quest.category for quest in quests if quest.category})
 
@@ -409,7 +418,8 @@ def index(game_id, quest_id, user_id):
         user_games=user_games_list,
         activities=activities,
         quests=quests,
-        calendar_quests=calendar_quests,
+        upcoming_calendar_quests=upcoming_calendar_quests,
+        past_calendar_quests=past_calendar_quests,
         categories=categories,
         show_join_modal=show_join_modal,
         show_join_custom=show_join_custom,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -323,6 +323,45 @@
                 </table>
                 </div>
                 <div class="quest-tab-content" id="calendar-quests-tab">
+                <h4>Upcoming</h4>
+                <table class="table quest-table mb-4">
+                    <colgroup>
+                        <col>
+                        <col>
+                        <col>
+                        <col>
+                    </colgroup>
+                    <thead>
+                        <tr>
+                            <th class="quest-table-header title">Quest</th>
+                            <th class="quest-table-header">Your Posts</th>
+                            <th class="quest-table-header">All Posts</th>
+                            <th class="quest-table-header">Points</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% set prev_date = None %}
+                        {% for quest in upcoming_calendar_quests %}
+                        {% set qdate = quest.calendar_event_start.date() if quest.calendar_event_start else None %}
+                        {% if qdate != prev_date %}
+                        <tr class="table-secondary">
+                            <td colspan="4">{{ qdate.strftime('%Y-%m-%d') if qdate else 'No Date' }}</td>
+                        </tr>
+                        {% set prev_date = qdate %}
+                        {% endif %}
+                        <tr class="quest-row" data-category="{{ quest.category or 'Calendar' }}" data-quest-id="{{ quest.id }}">
+                            <td class="quest-title-cell">
+                                <button type="button" class="btn btn-sm btn-outline-primary quest-inline-view-btn" data-quest-detail="{{ quest.id }}">View</button>
+                                <a href="javascript:void(0)" class="quest-title text-decoration-none ms-2" data-quest-detail="{{ quest.id }}">{{ quest.title }}</a>
+                            </td>
+                            <td class="quest-stats-cell">{{ quest.personal_completions }}</td>
+                            <td class="quest-stats-cell">{{ quest.total_completions }}</td>
+                            <td class="quest-stats-cell">{{ quest.points }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <h4 class="mt-4">Past</h4>
                 <table class="table quest-table">
                     <colgroup>
                         <col>
@@ -340,23 +379,7 @@
                     </thead>
                     <tbody>
                         {% set prev_date = None %}
-                        {% set shown_upcoming = false %}
-                        {% set shown_past = false %}
-                        {% for quest in calendar_quests %}
-                        {% set is_past = quest.calendar_event_start and quest.calendar_event_start < now %}
-                        {% if not is_past and not shown_upcoming %}
-                        <tr class="table-primary">
-                            <td colspan="4">Upcoming</td>
-                        </tr>
-                        {% set shown_upcoming = true %}
-                        {% endif %}
-                        {% if is_past and not shown_past %}
-                        <tr class="table-primary">
-                            <td colspan="4">Past</td>
-                        </tr>
-                        {% set prev_date = None %}
-                        {% set shown_past = true %}
-                        {% endif %}
+                        {% for quest in past_calendar_quests %}
                         {% set qdate = quest.calendar_event_start.date() if quest.calendar_event_start else None %}
                         {% if qdate != prev_date %}
                         <tr class="table-secondary">


### PR DESCRIPTION
## Summary
- group calendar quests into separate Upcoming and Past tables
- split calendar events in the backend
- mention the new view in README

## Testing
- `pip install flask werkzeug flask-wtf flask-sqlalchemy flask-login sqlalchemy psycopg2-binary wtforms email-validator cryptography pyjwt gunicorn apscheduler qrcode[pil] openai pywebpush pytest python-dotenv rsa html-sanitizer requests-oauthlib redis rq google-cloud-storage google-api-python-client`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f61f95058832ba9d8485102e27c86