### PR TITLE
Fix debug CSRF issue

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -131,6 +131,7 @@ def create_app(config_overrides=None):
         "INSTAGRAM_ACCESS_TOKEN": inscopeconfig.social.instagram_access_token,
         "INSTAGRAM_USER_ID": inscopeconfig.social.instagram_user_id,
         "TWA_SHA256_FINGERPRINT": inscopeconfig.twa.SHA256_CERT_FINGERPRINT,
+        "WTF_CSRF_ENABLED": not inscopeconfig.flask.DEBUG,
 
         "DEFAULT_SUPER_ADMIN_USERNAME": inscopeconfig.encryption.DEFAULT_SUPER_ADMIN_USERNAME,
         "DEFAULT_SUPER_ADMIN_PASSWORD": inscopeconfig.encryption.DEFAULT_SUPER_ADMIN_PASSWORD,

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -303,6 +303,7 @@ sent. Ensure `SECRET_KEY` is defined and access the site using the host specifie
 `LOCAL_DOMAIN` (typically `localhost:5000`).
 
 When `DEBUG=true`, JavaScript helpers skip sending CSRF tokens to simplify local testing.
+CSRF protection on the server is also disabled in this mode so requests succeed without the token.
 
 Log messages are saved to `logs/application.log`. Debug messages only appear
 when the application runs with `DEBUG=true` or `flask run --debug`.


### PR DESCRIPTION
## Summary
- disable CSRF enforcement when DEBUG is enabled
- document that CSRF protection is disabled in debug mode

## Testing
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a5fea510832bb4806dfdb20ace2d