### PR TITLE
Fix calendar quest description handling

### DIFF
--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -85,9 +85,15 @@ def sync_google_calendar_events() -> None:
             start_dt = (
                 datetime.fromisoformat(start_str).astimezone(UTC) if start_str else None
             )
+            description = ev.get("description", "") or ""
+            clean_desc = re.sub(
+                r'<a href="https://questbycycle.org/\?quest_shortcut=\d+">View Quest</a>\n?',
+                "",
+                description,
+            )
             quest = Quest(
                 title=ev.get("summary") or "Calendar Quest",
-                description=ev.get("description") or "",
+                description=clean_desc,
                 points=100,
                 game_id=game.id,
                 completion_limit=1,
@@ -101,13 +107,7 @@ def sync_google_calendar_events() -> None:
             db.session.add(quest)
             db.session.flush()
             quest_url = f"https://questbycycle.org/?quest_shortcut={quest.id}"
-            description = ev.get("description", "") or ""
-            description = re.sub(
-                r'<a href="https://questbycycle.org/\?quest_shortcut=\d+">View Quest</a>\n?',
-                "",
-                description,
-            )
-            new_desc = f"<a href=\"{quest_url}\">View Quest</a>\n{description}"
+            new_desc = f"<a href=\"{quest_url}\">View Quest</a>\n{clean_desc}"
             try:
                 service.events().patch(
                     calendarId=calendar_id,

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -76,3 +76,61 @@ def test_calendar_sync_creates_photo_quest(app, monkeypatch, tmp_path):
         assert quest is not None
         assert quest.points == 100
         assert quest.verification_type == "photo"
+
+
+def test_calendar_sync_strips_link_from_description(app, monkeypatch, tmp_path):
+    with app.app_context():
+        service_file = tmp_path / "svc.json"
+        service_file.write_text("{}")
+        game = Game(
+            title="CalGame",
+            start_date=datetime.now(timezone.utc) - timedelta(days=1),
+            end_date=datetime.now(timezone.utc) + timedelta(days=1),
+            admin_id=1,
+            calendar_service_json_path=str(service_file),
+            calendar_url="https://calendar.google.com/calendar/embed?src=test",
+        )
+        db.session.add(game)
+        db.session.commit()
+
+        start = datetime.now(timezone.utc)
+        raw_desc = (
+            '<a href="https://questbycycle.org/?quest_shortcut=1">View Quest</a>\n'
+            'Meet at the park.'
+        )
+
+        class FakeEvents:
+            def list(self, **_):
+                return self
+
+            def patch(self, **_):
+                class X:
+                    def execute(self):
+                        pass
+
+                return X()
+
+            def execute(self):
+                return {
+                    "items": [
+                        {
+                            "id": "E2",
+                            "summary": "Event",
+                            "description": raw_desc,
+                            "start": {"dateTime": start.isoformat()},
+                        }
+                    ]
+                }
+
+        class FakeService:
+            def events(self):
+                return FakeEvents()
+
+        monkeypatch.setattr(calendar_utils.Credentials, "from_service_account_file", lambda *a, **k: None)
+        monkeypatch.setattr(calendar_utils, "build", lambda *a, **k: FakeService())
+
+        calendar_utils.sync_google_calendar_events()
+
+        quest = Quest.query.filter_by(calendar_event_id="E2").first()
+        assert quest is not None
+        assert quest.description == "Meet at the park."


### PR DESCRIPTION
## Summary
- strip quest link from incoming calendar event description
- test calendar sync doesn't copy the link into quest descriptions

## Testing
- `pip install flask werkzeug flask-wtf flask-sqlalchemy flask-login sqlalchemy psycopg[binary] wtforms email-validator cryptography pyjwt gunicorn apscheduler qrcode[pil] openai pywebpush pytest python-dotenv rsa html-sanitizer requests-oauthlib redis rq psycopg2-binary google-cloud-storage google-api-python-client`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851dff29700832b934ccf69b1cd527a