### PR TITLE
Fix placeholder path for missing quest badges

### DIFF
--- a/app/quests.py
+++ b/app/quests.py
@@ -576,7 +576,7 @@ def quest_user_completion(quest_id):
             "image": badge.image,
         }
         if badge
-        else {"name": "Default", "image": current_app.config["PLACEHOLDER_IMAGE"]}
+        else {"name": "Default", "image": None}
     )
 
     quest_info = {


### PR DESCRIPTION
## Summary
- avoid adding `images/` prefix to placeholder badge names in quest detail API

## Testing
- `PYTHONPATH="$PWD" pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6851e58a3e34832bbc38db6801e18182