### PR TITLE
Fix VAPID key generation docs

### DIFF
--- a/docs/PUSH_NOTIFICATIONS.md
+++ b/docs/PUSH_NOTIFICATIONS.md
@@ -6,7 +6,7 @@ QuestByCycle supports optional Web Push notifications so users can receive updat
 
 1. Generate VAPID keys using the `pywebpush` utility:
    ```bash
-   python -m py_vapid generate --mailto you@example.com
+   python -m py_vapid --gen --mailto you@example.com
    ```
    This prints a public and private key pair.
 


### PR DESCRIPTION
## Summary
- fix push notification docs to use `--gen`

## Testing
- `pip install flask werkzeug flask-wtf flask-sqlalchemy flask-login sqlalchemy 'psycopg[binary]' wtforms email-validator cryptography pyjwt gunicorn apscheduler 'qrcode[pil]' openai pywebpush pytest python-dotenv rsa html-sanitizer requests-oauthlib redis rq psycopg2-binary google-cloud-storage google-api-python-client`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d7c7d0f8832b97c37ab90ac38af8