### PR TITLE
Add file upload for calendar service json

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -195,7 +195,10 @@ class GameForm(FlaskForm):
     instagram_user_id = StringField("Instagram User ID", validators=[Optional()])
     instagram_access_token = StringField("Instagram Access Token", validators=[Optional()])
     calendar_url = StringField("Calendar URL", validators=[Optional(), URL()])
-    calendar_service_json_path = StringField("Calendar Service JSON Path", validators=[Optional()])
+    calendar_service_json_path = FileField(
+        "Calendar Service JSON File",
+        validators=[Optional(), FileAllowed(["json"], "JSON files only!")],
+    )
     custom_game_code = StringField("Custom Game Code", validators=[Optional()])
     is_public = BooleanField("Public Game", default=True)
     allow_joins = BooleanField("Allow Joining", default=True)

--- a/app/templates/create_game.html
+++ b/app/templates/create_game.html
@@ -171,9 +171,9 @@
             <small class="form-text text-muted">Embed link for the game's calendar.</small>
         </div>
         <div class="form-group">
-            <label for="calendar_service_json_path">Calendar Service JSON Path</label>
+            <label for="calendar_service_json_path">Calendar Service JSON File</label>
             {{ form.calendar_service_json_path(class_="form-control", id="calendar_service_json_path") }}
-            <small class="form-text text-muted">Path to Google service account JSON.</small>
+            <small class="form-text text-muted">Upload Google service account JSON.</small>
         </div>
         <button type="submit" class="btn btn-primary">Create Game</button>
     </form>

--- a/app/templates/update_game.html
+++ b/app/templates/update_game.html
@@ -132,9 +132,12 @@
             <small class="form-text text-muted">Embed link for the game's calendar.</small>
         </div>
         <div class="form-group">
-            <label for="calendar_service_json_path">Calendar Service JSON Path</label>
+            <label for="calendar_service_json_path">Calendar Service JSON File</label>
+            {% if calendar_service_json_path %}
+                <p>Current file: {{ calendar_service_json_path }}</p>
+            {% endif %}
             {{ form.calendar_service_json_path(class_="form-control", id="calendar_service_json_path") }}
-            <small class="form-text text-muted">Path to Google service account JSON.</small>
+            <small class="form-text text-muted">Upload Google service account JSON.</small>
         </div>
         <button type="submit" class="btn btn-primary">Update Game</button>
     </form>

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -242,6 +242,7 @@ from .file_uploads import (
     ALLOWED_VIDEO_EXTENSIONS,
     MAX_IMAGE_BYTES,
     MAX_VIDEO_BYTES,
+    MAX_JSON_BYTES,
     allowed_file,
     allowed_image_file,
     allowed_video_file,
@@ -257,6 +258,7 @@ from .file_uploads import (
     save_submission_video,
     public_media_url,
     save_sponsor_logo,
+    save_calendar_service_json,
 )
 
 from .email_utils import (
@@ -280,6 +282,7 @@ __all__ = [
     "ALLOWED_VIDEO_EXTENSIONS",
     "MAX_IMAGE_BYTES",
     "MAX_VIDEO_BYTES",
+    "MAX_JSON_BYTES",
     "MAX_POINTS_INT",
     "REQUEST_TIMEOUT",
     "allowed_file",
@@ -297,6 +300,7 @@ __all__ = [
     "save_submission_video",
     "public_media_url",
     "save_sponsor_logo",
+    "save_calendar_service_json",
     "send_email",
     "send_social_media_liaison_email",
     "check_and_send_liaison_emails",

--- a/docs/NEWGAME.md
+++ b/docs/NEWGAME.md
@@ -91,14 +91,14 @@ You will see a form with the following fields. Fill them out as described:
     - **Purpose**: Optional link to an external calendar for the game.
     - **Interaction**: When provided, participants see a Calendar tab with the embedded calendar.
     - **Example**: `https://calendar.google.com/calendar/embed?src=your_calendar_id&ctz=America/Los_Angeles`.
-14. **Calendar Service JSON Path**:
-    - **Purpose**: Path to a Google service account JSON file for syncing calendar events.
+14. **Calendar Service JSON File**:
+    - **Purpose**: Upload a Google service account JSON file for syncing calendar events.
     - **Interaction**: When set, new events create quests automatically every 15 minutes.
       Imported calendar quests require a photo submission, award 100 points, and
       cannot be submitted until the event's start time. Submissions remain
       allowed after the event ends. Only events scheduled within the next two
       weeks are imported; past events are ignored.
-    - **Example**: `/home/user/service.json`.
+    - **Example**: select your downloaded `service-account.json` file.
 
 ### Step 3: Social Media Integration
 


### PR DESCRIPTION
## Summary
- allow uploading a calendar service JSON file when creating or editing a game
- handle uploaded service credentials server-side
- document the new upload field

## Testing
- `pip install flask flask-wtf flask-sqlalchemy flask-login sqlalchemy email-validator cryptography pyjwt gunicorn apscheduler qrcode openai pywebpush python-dotenv rsa html-sanitizer requests-oauthlib redis rq psycopg2-binary google-cloud-storage google-api-python-client`
- `pip install pillow`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544c26c838832b9fdb44958b2b2089