### PR TITLE
Fix relative path for calendar service JSON

### DIFF
--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -39,6 +39,8 @@ def sync_google_calendar_events() -> None:
         if not calendar_id:
             continue
         path = game.calendar_service_json_path
+        if not os.path.isabs(path):
+            path = os.path.join(current_app.static_folder, path)
         if not os.path.isfile(path):
             current_app.logger.warning(
                 "Calendar service JSON missing for game %s", game.id

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from datetime import datetime, timezone, timedelta
 
 import pytest
@@ -134,3 +135,58 @@ def test_calendar_sync_strips_link_from_description(app, monkeypatch, tmp_path):
         quest = Quest.query.filter_by(calendar_event_id="E2").first()
         assert quest is not None
         assert quest.description == "Meet at the park."
+
+
+def test_calendar_sync_relative_service_path(app, monkeypatch, tmp_path):
+    with app.app_context():
+        service_dir = Path(app.static_folder) / "service_json"
+        service_dir.mkdir(parents=True, exist_ok=True)
+        service_file = service_dir / "svc.json"
+        service_file.write_text("{}")
+        game = Game(
+            title="RelPath",
+            start_date=datetime.now(timezone.utc) - timedelta(days=1),
+            end_date=datetime.now(timezone.utc) + timedelta(days=1),
+            admin_id=1,
+            calendar_service_json_path=os.path.join("service_json", service_file.name),
+            calendar_url="https://calendar.google.com/calendar/embed?src=test",
+        )
+        db.session.add(game)
+        db.session.commit()
+
+        start = datetime.now(timezone.utc)
+
+        class FakeEvents:
+            def list(self, **_):
+                return self
+
+            def patch(self, **_):
+                class X:
+                    def execute(self):
+                        pass
+
+                return X()
+
+            def execute(self):
+                return {
+                    "items": [
+                        {
+                            "id": "E3",
+                            "summary": "Event",
+                            "description": "desc",
+                            "start": {"dateTime": start.isoformat()},
+                        }
+                    ]
+                }
+
+        class FakeService:
+            def events(self):
+                return FakeEvents()
+
+        monkeypatch.setattr(calendar_utils.Credentials, "from_service_account_file", lambda *a, **k: None)
+        monkeypatch.setattr(calendar_utils, "build", lambda *a, **k: FakeService())
+
+        calendar_utils.sync_google_calendar_events()
+
+        quest = Quest.query.filter_by(calendar_event_id="E3").first()
+        assert quest is not None


### PR DESCRIPTION
## Summary
- resolve calendar JSON path from static folder when relative
- test calendar sync using a relative service path

## Testing
- `pip install flask==3.1.1 flask-wtf==1.2.2 flask-sqlalchemy==3.1.1 flask-login==0.6.3 sqlalchemy==2.0.41 psycopg[binary]==3.2.9 wtforms==3.2.1 email-validator==2.2.0 cryptography==45.0.2 pyjwt==2.10.1 gunicorn==23.0.0 apscheduler==3.11.0 qrcode[pil]==8.2 openai==1.82.0 pywebpush==1.14.0 pytest==8.3.5 python-dotenv==1.1.0 rsa==4.9.1 html-sanitizer==2.5.0 requests-oauthlib==2.0.0 redis==5.0.4 rq==2.3.3 psycopg2-binary==2.9.10 google-cloud-storage==2.16.0 google-api-python-client==2.126.0`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545540d584832b92806fbd0cff7ad9