### PR TITLE
Fix int parsing for query params

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -10,7 +10,7 @@ from app.models.game import Game, Sponsor
 from app.models.quest import QuestSubmission
 from app.forms import SponsorForm
 from app.utils.file_uploads import save_sponsor_logo
-from app.utils import sanitize_html
+from app.utils import sanitize_html, get_int_param
 from app.decorators import require_admin, require_super_admin
 
 admin_bp = Blueprint('admin', __name__)
@@ -279,7 +279,7 @@ def delete_user(user_id):
 @require_admin
 def edit_sponsor(sponsor_id):
     sponsor = Sponsor.query.get_or_404(sponsor_id)
-    game_id = sponsor.game_id if sponsor.game_id else request.args.get('game_id', type=int)
+    game_id = sponsor.game_id if sponsor.game_id else get_int_param('game_id')
 
     form = SponsorForm(obj=sponsor)
     form.game_id.data = game_id                                               
@@ -313,7 +313,7 @@ def edit_sponsor(sponsor_id):
 @require_admin
 def delete_sponsor(sponsor_id):
 
-    game_id = request.form.get('game_id', type=int)                                       
+    game_id = get_int_param('game_id', source=request.form)
 
     sponsor = Sponsor.query.get_or_404(sponsor_id)
     db.session.delete(sponsor)
@@ -331,7 +331,7 @@ def delete_sponsor(sponsor_id):
 
 @admin_bp.route('/sponsors', methods=['GET'])
 def sponsors():
-    game_id = request.args.get('game_id', type=int)
+    game_id = get_int_param('game_id')
     if game_id:
         sponsors = Sponsor.query.filter_by(game_id=game_id).all()
     else:
@@ -344,9 +344,9 @@ def sponsors():
 @require_admin
 def manage_sponsors():
 
-    game_id = request.args.get('game_id', type=int)
+    game_id = get_int_param('game_id')
     if request.method == 'POST':
-        game_id = request.form.get('game_id', type=int)
+        game_id = get_int_param('game_id', source=request.form)
 
     form = SponsorForm()
     form.game_id.data = game_id                           

--- a/app/badges.py
+++ b/app/badges.py
@@ -21,6 +21,7 @@ from app.decorators import require_admin
 from .forms import BadgeForm
                                                           
 from .utils import save_badge_image
+from app.utils import get_int_param
 from .models import db, Quest, Badge, UserQuest, Game
 from werkzeug.utils import secure_filename
 
@@ -70,7 +71,7 @@ def create_badge():
 
 @badges_bp.route('', methods=['GET'])
 def get_badges():
-    game_id = request.args.get('game_id', type=int)
+    game_id = get_int_param('game_id')
     if game_id:
         game = db.session.get(Game, game_id)
         if not game:

--- a/app/main.py
+++ b/app/main.py
@@ -54,7 +54,7 @@ from app.utils.file_uploads import (
     save_bicycle_picture,
     correct_image_orientation,
 )
-from app.utils import sanitize_html
+from app.utils import sanitize_html, get_int_param
 from .config import load_config, AppConfig
 from app.tasks import enqueue_email
 
@@ -291,7 +291,7 @@ def index(game_id, quest_id, user_id):
 
                                                                        
                                                                              
-    query_game_id = request.args.get('game_id', type=int)
+    query_game_id = get_int_param('game_id')
     if query_game_id is not None:
         game_id = query_game_id
 
@@ -503,8 +503,8 @@ def shout_board_messages(game_id):
     """
     Return JSON: { pinned: [...], messages: [...], has_next: bool }.
     """
-    page     = request.args.get('page', 1, type=int)
-    per_page = request.args.get('per_page', 20, type=int)
+    page     = get_int_param('page', default=1)
+    per_page = get_int_param('per_page', default=20)
 
                                     
     pinned = []
@@ -554,7 +554,7 @@ def leaderboard_partial():
     """
     Provide leaderboard data for a specific game.
     """
-    selected_game_id = request.args.get('game_id', type=int)
+    selected_game_id = get_int_param('game_id')
     if not selected_game_id:
         return jsonify({'error': 'Missing or invalid game_id'}), 400
 
@@ -978,7 +978,7 @@ def manifest():
     with open(base_path) as f:
         data = json.load(f)
 
-    game_id = request.args.get('game_id', type=int)
+    game_id = get_int_param('game_id')
     if not game_id and current_user.is_authenticated:
         game_id = current_user.selected_game_id
 

--- a/app/quests.py
+++ b/app/quests.py
@@ -30,7 +30,7 @@ from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.utils import secure_filename
 from app.forms import PhotoForm, QuestForm
 from app.social import post_to_social_media
-from app.utils import REQUEST_TIMEOUT, sanitize_html
+from app.utils import REQUEST_TIMEOUT, sanitize_html, get_int_param
 from app.utils.quest_scoring import (
     can_complete_quest,
     check_and_award_badges,
@@ -952,9 +952,9 @@ def get_all_submissions():
         limit   (int): Number of submissions to return (default 10).
     """
 
-    game_id = request.args.get("game_id", type=int)
-    offset = request.args.get("offset", 0, type=int)
-    limit = request.args.get("limit", 10, type=int)
+    game_id = get_int_param("game_id")
+    offset = get_int_param("offset", default=0)
+    limit = get_int_param("limit", default=10)
 
     if game_id is None:
         return

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -69,6 +69,34 @@ def safe_url_for(*args, **kwargs):
 def sanitize_html(html_content: str) -> str:
     return SANITIZER.sanitize(html_content)
 
+
+def get_int_param(name: str, *, source=None, default: int | None = None) -> int | None:
+    """Safely retrieve an integer parameter from the request.
+
+    Parameters
+    ----------
+    name:
+        The parameter name to fetch.
+    source:
+        The data source, defaults to ``request.args``.
+    default:
+        Value returned if the parameter is missing or invalid.
+
+    Returns
+    -------
+    int | None
+        Parsed integer or ``default`` when conversion fails.
+    """
+
+    source = source or request.args
+    raw = source.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
 # ----------------------------------------------------------------------------
 # Misc database helpers
 # ----------------------------------------------------------------------------
@@ -316,4 +344,5 @@ __all__ = [
     "get_game_badges",
     "safe_url_for",
     "sanitize_html",
+    "get_int_param",
 ]

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -178,6 +178,7 @@ Utility functions are organized under `app/utils/` and include:
 - **`update_user_score`**: Updates a user's score.
 - **`award_badges`**: Awards badges to users.
 - **`can_complete_quest`**: Checks if a user can complete a quest.
+- **`get_int_param`**: Safely parses integers from request data.
 - **`send_email`**: Sends emails.
 
 ## Admin Functionality

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from flask import url_for
 
 from app import create_app
 from app.utils.file_uploads import public_media_url, allowed_image_file
+from app.utils import get_int_param
 
 @pytest.fixture
 def app():
@@ -98,3 +99,12 @@ def test_save_submission_image_too_large(app):
 
     with pytest.raises(ValueError):
         save_submission_image(file)
+
+
+def test_get_int_param_parsing(app):
+    """Ensure get_int_param converts values safely."""
+    with app.test_request_context('/?a=1&b=&c=foo'):
+        assert get_int_param('a') == 1
+        assert get_int_param('b') is None
+        assert get_int_param('c') is None
+        assert get_int_param('missing', default=7) == 7


### PR DESCRIPTION
## Summary
- add `get_int_param` helper to parse integer params safely
- use helper in admin, main, quests and badges routes
- document helper
- test the new function

## Testing
- `pip install flask==3.1.1 werkzeug==3.1.3 flask-wtf==1.2.2 flask-sqlalchemy==3.1.1 flask-login==0.6.3 sqlalchemy==2.0.41 psycopg[binary]==3.2.9 wtforms==3.2.1 email-validator==2.2.0 cryptography==45.0.2 pyjwt==2.10.1 gunicorn==23.0.0 apscheduler==3.11.0 "qrcode[pil]"==8.2 openai==1.82.0 pywebpush==1.14.0 pytest==8.3.5 python-dotenv==1.1.0 rsa==4.9.1 html-sanitizer==2.5.0 requests-oauthlib==2.0.0 redis==5.0.4 rq==2.3.3 psycopg2-binary==2.9.10 google-cloud-storage==2.16.0 google-api-python-client==2.126.0`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545dc65514832b83e782ac05796d68