### PR TITLE
Fix participant count in leaderboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -591,7 +591,10 @@ def leaderboard_partial():
     ).filter(Quest.game_id == selected_game_id
     ).scalar() or 0
 
-    num_participants = len(game.participants)
+    # Use the user_games association to count participants. Older
+    # `game_participants` table is no longer updated when users join a game,
+    # so relying on `game.participants` returns an incorrect count of zero.
+    num_participants = len(game.game_participants)
     num_quests = Quest.query.filter_by(game_id=selected_game_id).count()
     avg_points = round(total_game_points / num_participants, 2) if num_participants else 0
     secondary_stats = [


### PR DESCRIPTION
## Summary
- use the correct association for counting game participants

## Testing
- `pip install flask==3.1.1 flask-wtf==1.2.2 flask-sqlalchemy==3.1.1 flask-login==0.6.3 sqlalchemy==2.0.41 psycopg[binary]==3.2.9 wtforms==3.2.1 email-validator==2.2.0 cryptography==45.0.2 pyjwt==2.10.1 gunicorn==23.0.0 apscheduler==3.11.0 qrcode[pil]==8.2 openai==1.82.0 pywebpush==1.14.0 pytest==8.3.5 python-dotenv==1.1.0 rsa==4.9.1 html-sanitizer==2.5.0 requests-oauthlib==2.0.0 redis==5.0.4 rq==2.3.3 psycopg2-binary==2.9.10 google-cloud-storage==2.16.0 google-api-python-client==2.126.0 werkzeug==3.1.3`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685550a7d348832b9cb92d734c174269