### PR TITLE
Fix calendar timezone display

### DIFF
--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -84,9 +84,9 @@ def sync_google_calendar_events() -> None:
             if Quest.query.filter_by(calendar_event_id=ev_id, game_id=game.id).first():
                 continue
             start_str = ev.get("start", {}).get("dateTime")
-            start_dt = (
-                datetime.fromisoformat(start_str).astimezone(UTC) if start_str else None
-            )
+            start_dt = datetime.fromisoformat(start_str) if start_str else None
+            if start_dt and not start_dt.tzinfo:
+                start_dt = start_dt.replace(tzinfo=UTC)
             description = ev.get("description", "") or ""
             clean_desc = re.sub(
                 r'<a href="https://questbycycle.org/\?quest_shortcut=\d+">View Quest</a>\n?',

--- a/docs/NEWGAME.md
+++ b/docs/NEWGAME.md
@@ -99,6 +99,7 @@ You will see a form with the following fields. Fill them out as described:
       allowed after the event ends. Only events scheduled within the next two
       weeks are imported; past events are ignored.
     - **Example**: select your downloaded `service-account.json` file.
+    - Event times use the calendar's timezone, so quest headings match the local date of each event.
 
 ### Step 3: Social Media Integration
 


### PR DESCRIPTION
## Summary
- keep event timezone when syncing Google Calendar
- document that calendar quests display in the event's timezone

## Testing
- `pip install flask werkzeug flask-wtf flask-sqlalchemy flask-login sqlalchemy psycopg[binary] wtforms email-validator cryptography pyjwt gunicorn apscheduler qrcode[pil] openai pywebpush pytest python-dotenv rsa html-sanitizer requests-oauthlib redis rq psycopg2-binary google-cloud-storage google-api-python-client`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556690ae28832b92ecaf051285aee8