### PR TITLE
Fix calendar quest date display

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -346,7 +346,7 @@
                     <tbody>
                         {% set prev_date = None %}
                         {% for quest in upcoming_calendar_quests %}
-                        {% set qdate = quest.calendar_event_start.date() if quest.calendar_event_start else None %}
+                        {% set qdate = quest.display_date %}
                         {% if qdate != prev_date %}
                         <tr class="table-secondary">
                             <td colspan="4">
@@ -390,7 +390,7 @@
                     <tbody>
                         {% set prev_date = None %}
                         {% for quest in past_calendar_quests %}
-                        {% set qdate = quest.calendar_event_start.date() if quest.calendar_event_start else None %}
+                        {% set qdate = quest.display_date %}
                         {% if qdate != prev_date %}
                         <tr class="table-secondary">
                             <td colspan="4">

--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -27,6 +27,13 @@ def _parse_calendar_id(url: str) -> str | None:
     return None
 
 
+def _parse_calendar_tz(url: str) -> str | None:
+    """Return timezone name from a Google calendar embed URL if present."""
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    return qs.get("ctz", [None])[0]
+
+
 def sync_google_calendar_events() -> None:
     """Create quests from new Google Calendar events."""
     games = Game.query.filter(

--- a/tests/test_quest_display.py
+++ b/tests/test_quest_display.py
@@ -6,7 +6,13 @@ from app.models.game import Game
 from app.models.user import User
 from app.models.quest import Quest, QuestSubmission
 from app.models.badge import Badge
-from app.main import _prepare_quests, _prepare_user_data, _sort_calendar_quests
+from zoneinfo import ZoneInfo
+from app.main import (
+    _prepare_quests,
+    _prepare_user_data,
+    _sort_calendar_quests,
+    _calendar_display_date,
+)
 
 
 @pytest.fixture
@@ -239,3 +245,9 @@ def test_calendar_quest_can_verify_after_start(app):
         quests, _ = _prepare_quests(game, admin.id, [], later)
         q = next(q for q in quests if q.id == quest.id)
         assert q.can_verify
+
+
+def test_calendar_display_date_converts_to_calendar_tz():
+    dt = datetime(2025, 6, 22, 2, 0, tzinfo=timezone.utc)
+    tz = ZoneInfo("America/Los_Angeles")
+    assert _calendar_display_date(dt, tz) == dt.astimezone(tz).date()


### PR DESCRIPTION
## Summary
- parse calendar timezone from Google calendar URLs
- compute display date in that timezone
- show corrected dates for past calendar quests
- test timezone date conversion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_68556abe6ec4832bb4f6424c7bd07d0e