### PR TITLE
Fix login redirect loop for custom game join

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -339,7 +339,10 @@ def login():
 
                                                           
     if request.method == 'GET':
-        show_login_flag = 0 if next_page else 1
+        if show_join == '1':
+            show_login_flag = 1
+        else:
+            show_login_flag = 0 if next_page else 1
 
         return redirect(
             safe_url_for(


### PR DESCRIPTION
## Summary
- prevent infinite redirects when joining a custom game while not logged in

## Testing
- `pip install flask pytest flask-wtf flask-sqlalchemy flask-login sqlalchemy psycopg[binary] wtforms email-validator cryptography pyjwt gunicorn apscheduler qrcode[pil] openai pywebpush pytest python-dotenv rsa html-sanitizer requests-oauthlib redis rq psycopg2-binary google-cloud-storage google-api-python-client`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a3986318832ba5d7fe84f3a767fd