### PR TITLE
Remove HEIC image support

### DIFF
--- a/app/utils/file_uploads.py
+++ b/app/utils/file_uploads.py
@@ -11,7 +11,11 @@ from werkzeug.utils import secure_filename
 from PIL import Image, ExifTags, UnidentifiedImageError
 
 ALLOWED_IMAGE_EXTENSIONS = {
-    "png", "jpg", "jpeg", "gif", "webp", "heif", "heic"
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "webp",
 }
 ALLOWED_VIDEO_EXTENSIONS = {"mp4", "webm", "mov"}
 

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -78,9 +78,8 @@ The dashboard is your central hub for accessing games, quests, and community fea
 
 ### Quest Verification
 
-Quests can have different verification methods:
 - **Photo Verification**: Upload a photo as evidence of quest completion.
-- **Supported Image Formats**: PNG, JPG/JPEG, GIF, WebP, and HEIF/HEIC.
+- **Supported Image Formats**: PNG, JPG/JPEG, GIF, and WebP.
 - **Image Size Limit**: Images must be 8 MB or smaller.
 - **Comment Verification**: Provide a comment describing how you completed the quest.
 - **Photo and Comment Verification**: Both upload a photo and provide a comment.

--- a/scripts/remove_heic_submissions.py
+++ b/scripts/remove_heic_submissions.py
@@ -1,0 +1,49 @@
+"""Remove quest submissions using HEIC or HEIF images."""
+
+from __future__ import annotations
+
+from app import create_app
+from app.models import db, QuestSubmission, Quest
+from app.utils.file_uploads import delete_media_file
+
+
+def _remove_submission(submission: QuestSubmission) -> None:
+    """Delete submission and associated media."""
+    delete_media_file(submission.image_url)
+    db.session.delete(submission)
+
+
+def _clear_quest_image(quest: Quest) -> None:
+    """Remove HEIC/HEIF evidence images from quests."""
+    delete_media_file(quest.evidence_url)
+    quest.evidence_url = None
+
+
+def remove_heic_content() -> None:
+    """Purge all HEIC or HEIF images from the database."""
+    app = create_app()
+    with app.app_context():
+        submissions = (
+            QuestSubmission.query.filter(
+                QuestSubmission.image_url.ilike("%.heic")
+            ).all()
+            + QuestSubmission.query.filter(
+                QuestSubmission.image_url.ilike("%.heif")
+            ).all()
+        )
+        for sub in submissions:
+            _remove_submission(sub)
+
+        quests = (
+            Quest.query.filter(Quest.evidence_url.ilike("%.heic")).all()
+            + Quest.query.filter(Quest.evidence_url.ilike("%.heif")).all()
+        )
+        for quest in quests:
+            _clear_quest_image(quest)
+
+        db.session.commit()
+        print(f"Removed {len(submissions)} submissions and {len(quests)} quests")
+
+
+if __name__ == "__main__":
+    remove_heic_content()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -83,9 +83,9 @@ def test_save_submission_image_invalid_extension(app, tmp_path):
 
 
 def test_allowed_image_file_heif():
-    """HEIF and HEIC images should be recognized as valid."""
-    assert allowed_image_file("photo.heif")
-    assert allowed_image_file("image.HEIC")
+    """HEIF and HEIC images should be rejected."""
+    assert not allowed_image_file("photo.heif")
+    assert not allowed_image_file("image.HEIC")
 
 
 def test_save_submission_image_too_large(app):


### PR DESCRIPTION
## Summary
- forbid `.heic` and `.heif` uploads
- document supported image formats only as PNG, JPG/JPEG, GIF and WebP
- test that HEIC/HEIF are rejected
- add script to purge existing HEIC submissions

## Testing
- `pip install Flask==3.1.1 Flask-WTF==1.2.2 Flask-SQLAlchemy==3.1.1 Flask-Login==0.6.3 sqlalchemy==2.0.41 psycopg2-binary==2.9.10 wtforms==3.2.1 email-validator==2.2.0 cryptography==45.0.2 pyjwt==2.10.1 gunicorn==23.0.0 APScheduler==3.11.0 qrcode[pil]==8.2 openai==1.82.0 pywebpush==1.14.0 python-dotenv==1.1.0 rsa==4.9.1 html-sanitizer==2.5.0 requests-oauthlib==2.0.0 redis==5.0.4 rq==2.3.3 google-cloud-storage==2.16.0 google-api-python-client==2.126.0 pytest==8.3.5 requests==2.31.0 pillow==10.3.0`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860bb8f0270832b8953b8b390a0fdb1