### PR TITLE
Fix missing app module in maintenance script

### DIFF
--- a/scripts/remove_heic_submissions.py
+++ b/scripts/remove_heic_submissions.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from app import create_app
 from app.models import db, QuestSubmission, Quest
 from app.utils.file_uploads import delete_media_file


### PR DESCRIPTION
## Summary
- fix PYTHONPATH issue in `remove_heic_submissions.py`

## Testing
- `pip install flask==3.1.1 werkzeug==3.1.3 flask-wtf==1.2.2 flask-sqlalchemy==3.1.1 flask-login==0.6.3 sqlalchemy==2.0.41 'psycopg[binary]==3.2.9' wtforms==3.2.1 email-validator==2.2.0 cryptography==45.0.2 pyjwt==2.10.1 gunicorn==23.0.0 apscheduler==3.11.0 'qrcode[pil]==8.2' openai==1.82.0 pywebpush==1.14.0 pytest==8.3.5 python-dotenv==1.1.0 rsa==4.9.1 html-sanitizer==2.5.0 requests-oauthlib==2.0.0 redis==5.0.4 rq==2.3.3 psycopg2-binary==2.9.10 google-cloud-storage==2.16.0 google-api-python-client==2.126.0`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d6abb7c8832b9d3d18563601d866