### PR TITLE
Fix submission deletion refresh error

### DIFF
--- a/frontend/modules/quest_detail_modal.js
+++ b/frontend/modules/quest_detail_modal.js
@@ -61,7 +61,7 @@ export function openQuestDetailModal(questId) {
 // Expose function globally for inline event handlers or legacy code
 window.openQuestDetailModal = openQuestDetailModal;
 
-function refreshQuestDetailModal(questId) {
+export function refreshQuestDetailModal(questId) {
   fetchJson(`/quests/detail/${questId}/user_completion`)
     .then(({ json: data }) => {
       const { quest, userCompletion, canVerify, nextEligibleTime } = data;
@@ -88,10 +88,13 @@ function refreshQuestDetailModal(questId) {
       lazyLoadImages();
       fetchQuestSubmissions(questId);
     })
-    .catch(err => {
+  .catch(err => {
       logger.error('Failed to refresh quest detail modal:', err);
     });
 }
+
+// Make refresh function available globally for other modules
+window.refreshQuestDetailModal = refreshQuestDetailModal;
 
 
 function lazyLoadImages() {

--- a/frontend/modules/submission_detail_modal.js
+++ b/frontend/modules/submission_detail_modal.js
@@ -1,6 +1,7 @@
 import { openModal, closeModal, resetModalContent } from './modal_common.js';
 import { csrfFetchJson, fetchJson } from '../utils.js';
 import { showUserProfileModal } from './user_profile_modal.js';
+import { refreshQuestDetailModal } from './quest_detail_modal.js';
 
 export let showSubmissionDetail;
 


### PR DESCRIPTION
## Summary
- export `refreshQuestDetailModal` and expose globally
- import `refreshQuestDetailModal` in the submission modal

## Testing
- `npm run build`
- `PYTHONPATH="$PWD" pytest` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_686196c94ad4832ba7324df0aeb3a5cb