### PR TITLE
Enhance navbar crossover indicator and link game logo

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -187,6 +187,7 @@ class GameForm(FlaskForm):
         "Game Logo",
         validators=[Optional(), FileAllowed(["jpg", "jpeg", "png"], "Images only!")],
     )
+    logo_url = StringField("Logo URL", validators=[Optional(), URL()])
     twitter_username = StringField("Twitter Username")
     twitter_api_key = StringField("Twitter API Key")
     twitter_api_secret = StringField("Twitter API Secret")

--- a/app/games.py
+++ b/app/games.py
@@ -52,6 +52,7 @@ def serialize_game(game):
         "calendar_url": game.calendar_url,
         "calendar_service_json_path": game.calendar_service_json_path,
         "logo": game.logo,
+        "logo_url": game.logo_url,
     }
 
 
@@ -76,6 +77,7 @@ def populate_game_from_form(game, form):
         "instagram_user_id",
         "instagram_access_token",
         "calendar_url",
+        "logo_url",
         "social_media_liaison_email",
     ]
 

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -47,6 +47,7 @@ class Game(db.Model):
     )
     leaderboard_image = db.Column(db.String(500), nullable=True)
     logo = db.Column(db.String(255), nullable=True)
+    logo_url = db.Column(db.String(500), nullable=True)
     twitter_username = db.Column(db.String(500), nullable=True)
     twitter_api_key = db.Column(db.String(500), nullable=True)
     twitter_api_secret = db.Column(db.String(500), nullable=True)

--- a/app/templates/create_game.html
+++ b/app/templates/create_game.html
@@ -94,6 +94,10 @@
             <label for="logo">Game Logo</label>
             {{ form.logo(class_="form-control", id="logo") }}
         </div>
+        <div class="form-group">
+            <label for="logo_url">Logo URL</label>
+            {{ form.logo_url(class_="form-control", id="logo_url") }}
+        </div>
         <div class="form-check form-switch">
             {{ form.is_public(class_="form-check-input", id="is_public") }}
             <label class="form-check-label" for="is_public">Is Public</label>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -90,9 +90,16 @@
                 alt="Quest by Cycle" class="align-middle">
       </a>
       {% if selected_game and selected_game.logo %}
-          x
-          <img src="{{ url_for('main.resize_image', path=selected_game.logo, width=80) }}"
-               alt="{{ selected_game.title }} logo" class="align-middle">
+          <span class="mx-2 fs-3 fw-bold align-middle">&times;</span>
+          {% if selected_game.logo_url %}
+              <a href="{{ selected_game.logo_url }}" target="_blank" rel="noopener">
+                  <img src="{{ url_for('main.resize_image', path=selected_game.logo, width=80) }}"
+                       alt="{{ selected_game.title }} logo" class="align-middle">
+              </a>
+          {% else %}
+              <img src="{{ url_for('main.resize_image', path=selected_game.logo, width=80) }}"
+                   alt="{{ selected_game.title }} logo" class="align-middle">
+          {% endif %}
       {% endif %}
       <!-- Hamburger for mobile -->
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse"

--- a/app/templates/update_game.html
+++ b/app/templates/update_game.html
@@ -57,6 +57,10 @@
             {% endif %}
             {{ form.logo(class_="form-control", id="logo") }}
         </div>
+        <div class="form-group">
+            <label for="logo_url">Logo URL</label>
+            {{ form.logo_url(class_="form-control", id="logo_url") }}
+        </div>
         <div class="form-check form-switch">
             {{ form.is_public(class_="form-check-input", id="is_public") }}
             <label class="form-check-label" for="is_public">Is Public</label>


### PR DESCRIPTION
## Summary
- Replace plain "x" with bold multiplication symbol to highlight crossover branding when a game logo is shown
- Allow specifying a URL for each game logo and make the navbar logo open that link in a new tab

## Testing
- `pip install flask flask-login flask-wtf flask-sqlalchemy email-validator sqlalchemy python-dotenv requests cryptography pyjwt gunicorn apscheduler "qrcode[pil]" openai pywebpush requests-oauthlib redis rq psycopg[binary] psycopg2-binary google-cloud-storage google-api-python-client html-sanitizer`
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896e145479c832b849e7cb0fbe7d01e