### PR TITLE
Ensure imported quests appear on index

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -185,14 +185,11 @@ def _prepare_quests(game, user_id, user_quests, now):
 
                                                                      
     quests = [
-        q for q in quests
+        q
+        for q in quests
         if q.from_calendar
         or not (
-            (
-                q.badge_id is None
-                or (q.badge is not None and not q.badge.image)
-            )
-            and q.total_completions == 0
+            q.badge_id is None and q.total_completions == 0
         )
     ]
 


### PR DESCRIPTION
## Summary
- Show quests without badge images on the index page so recently imported quests are visible

## Testing
- `PYTHONPATH="$PWD" pytest` *(fails: ModuleNotFoundError: No module named 'flask_login')*

------
https://chatgpt.com/codex/tasks/task_e_6897dc77ee44832bacbaf680ce4efac5