### PR TITLE
Limit admin access to assigned games

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -189,7 +189,8 @@ def _prepare_quests(game, user_id, user_quests, now):
         for q in quests
         if q.from_calendar
         or not (
-            q.badge_id is None and q.total_completions == 0
+            (q.badge is None or q.badge.image is None)
+            and q.total_completions == 0
         )
     ]
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -226,10 +226,22 @@ class User(UserMixin, db.Model):
         return total_score
 
     def is_admin_for_game(self, game_id):
-        """Return True if the user is an admin for the given game."""
+        """Return ``True`` if the user can administer the given game.
+
+        A user is considered an admin for a game if they either created the
+        game, were explicitly added as an admin, or have super admin rights.
+        """
         from .game import Game
+
         game = db.session.get(Game, game_id)
-        return bool(game and (self in game.admins or self.is_super_admin))
+        return bool(
+            game
+            and (
+                self.is_super_admin
+                or self in game.admins
+                or game.admin_id == self.id
+            )
+        )
 
     @property
     def unread_notifications_count(self):

--- a/app/templates/manage_badges.html
+++ b/app/templates/manage_badges.html
@@ -31,7 +31,7 @@
     <div id="uploadForm" class="form-container d-none">
         <h2>Upload Badge Images</h2>
         <h5>Uploaded folder of images match their filename to existing Badges (Badge Name: Nature Lover)(Uploaded image: nature_lover.png)</h5>
-        <form method="post" enctype="multipart/form-data" action="/badges/upload_images">
+        <form method="post" enctype="multipart/form-data" action="{{ url_for('badges.upload_images', game_id=game_id) }}">
             {{ form.hidden_tag() }}
             <input type="file" id="imageUpload" name="file" class="button" multiple webkitdirectory>
             <button type="submit" class="button">Upload Images</button>
@@ -42,7 +42,7 @@
         <p><h2>Add a Category Badge</h2></p>
         <h5>Added Category Badges are awarded upon completing the set of Quests with the same Category one time.</h5>
         <div class="badge-form">
-            <form action="{{ url_for('badges.manage_badges') }}" method="post" enctype="multipart/form-data">
+            <form action="{{ url_for('badges.manage_badges', game_id=game_id) }}" method="post" enctype="multipart/form-data">
                 {{ form.hidden_tag() }}
                 <div class="form-group">
                     {{ form.name.label }} {{ form.name() }}
@@ -64,7 +64,7 @@
     <div id="bulkUploadForm" class="form-container d-none">
         <h2>Bulk Upload Badges from a CSV file</h2>
         <h5>Uploaded images match their filename to Badge Name</h5>
-        <form method="post" enctype="multipart/form-data" action="/badges/bulk_upload">
+        <form method="post" enctype="multipart/form-data" action="{{ url_for('badges.bulk_upload', game_id=game_id) }}">
             {{ form.hidden_tag() }}
             <div class="form-group">
                 <label for="csvFile">CSV File</label>

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -34,6 +34,8 @@ Welcome to the Admin Guide for your Ultimate Challenge and Reward Platform. This
 
 As an admin, you have the ability to create, manage, and moderate games, quests, badges, and users. Your role is crucial in maintaining an engaging and supportive community. This guide will help you understand and utilize the various features available to you.
 
+Admins only see games they created or have been assigned to on the admin dashboard. This scoping ensures that badge and quest management remain limited to their designated games.
+
 ## Creating and Managing Games
 
 ### Creating a Game

--- a/tests/test_admin_dashboard_visibility.py
+++ b/tests/test_admin_dashboard_visibility.py
@@ -1,0 +1,81 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from flask_login import login_user
+
+from app import create_app, db
+from app.models.user import User
+from app.models.game import Game
+
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "MAIL_SERVER": None,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login_as(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    with client.application.test_request_context():
+        login_user(user)
+
+
+def test_admin_dashboard_shows_only_associated_games(client):
+    admin1 = User(
+        username="admin1",
+        email="admin1@example.com",
+        is_admin=True,
+        license_agreed=True,
+        email_verified=True,
+    )
+    admin1.set_password("pw")
+    admin2 = User(
+        username="admin2",
+        email="admin2@example.com",
+        is_admin=True,
+        license_agreed=True,
+        email_verified=True,
+    )
+    admin2.set_password("pw")
+    db.session.add_all([admin1, admin2])
+    db.session.commit()
+
+    game1 = Game(
+        title="Game 1",
+        admin_id=admin1.id,
+        start_date=datetime.now(timezone.utc) - timedelta(days=1),
+        end_date=datetime.now(timezone.utc) + timedelta(days=1),
+    )
+    game2 = Game(
+        title="Game 2",
+        admin_id=admin2.id,
+        start_date=datetime.now(timezone.utc) - timedelta(days=1),
+        end_date=datetime.now(timezone.utc) + timedelta(days=1),
+    )
+    db.session.add_all([game1, game2])
+    db.session.commit()
+
+    login_as(client, admin1)
+
+    resp = client.get("/admin/admin_dashboard")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "Game 1" in html
+    assert "Game 2" not in html


### PR DESCRIPTION
## Summary
- Show games in the admin dashboard only when the user is an admin or creator
- Scope badge management, uploads, and bulk badge import to a specific game
- Fix quest filtering to hide badges without images when not yet earned
- Document and test admin dashboard game scoping

## Testing
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ed08674c832b9d34230dbfac0d1b