### PR TITLE
Show all quests in main index

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -189,16 +189,6 @@ def _prepare_quests(game, user_id, user_quests, now):
     activities.sort(key=get_datetime, reverse=True)
 
                                                                      
-    quests = [
-        q
-        for q in quests
-        if q.from_calendar
-        or not (
-            (q.badge is None or q.badge.image is None)
-            and q.total_completions == 0
-        )
-    ]
-
     quests.sort(key=lambda x: (-x.is_sponsored, -x.personal_completions, -x.total_completions))
     return quests, activities
   

--- a/tests/test_quest_display.py
+++ b/tests/test_quest_display.py
@@ -32,7 +32,7 @@ def app():
     ctx.pop()
 
 
-def test_prepare_quests_hides_unbadged_empty(app):
+def test_prepare_quests_includes_unbadged_empty(app):
     with app.app_context():
         admin = User(username="admin", email="admin@example.com", license_agreed=True)
         admin.set_password("pw")
@@ -64,11 +64,11 @@ def test_prepare_quests_hides_unbadged_empty(app):
 
         quests, _ = _prepare_quests(game, admin.id, [], datetime.now(timezone.utc))
         ids = [q.id for q in quests]
-        assert q1.id not in ids
+        assert q1.id in ids
         assert q2.id in ids
 
 
-def test_prepare_quests_hides_badgeless_image(app):
+def test_prepare_quests_includes_badgeless_quests(app):
     with app.app_context():
         admin = User(username="admin2", email="admin2@example.com", license_agreed=True)
         admin.set_password("pw")
@@ -102,7 +102,7 @@ def test_prepare_quests_hides_badgeless_image(app):
 
         quests, _ = _prepare_quests(game, admin.id, [], datetime.now(timezone.utc))
         ids = [q.id for q in quests]
-        assert q1.id not in ids
+        assert q1.id in ids
         assert q2.id in ids
         assert q3.id in ids
 


### PR DESCRIPTION
## Summary
- Remove filter that hid quests lacking badges and completions
- Update quest display tests to match new behavior

## Testing
- `PYTHONPATH="$PWD" pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898526f7880832bbd3ad89d9f316081