### PR TITLE
Fix badge management game selection

### DIFF
--- a/app/badges.py
+++ b/app/badges.py
@@ -137,7 +137,9 @@ def get_badges():
 @login_required
 @require_admin
 def manage_badges():
-    game_id = get_int_param('game_id')
+    game_id = get_int_param("game_id")
+    if game_id is None:
+        game_id = get_int_param("game_id", source=request.form)
     if not current_user.is_super_admin and not current_user.is_admin_for_game(game_id):
         abort(403)
 

--- a/app/templates/manage_badges.html
+++ b/app/templates/manage_badges.html
@@ -45,6 +45,7 @@
         <div class="badge-form">
             <form action="{{ url_for('badges.manage_badges', game_id=game_id) }}" method="post" enctype="multipart/form-data">
                 {{ form.hidden_tag() }}
+                <input type="hidden" name="game_id" value="{{ game_id }}">
                 <div class="form-group">
                     {{ form.name.label }} {{ form.name() }}
                 </div>

--- a/tests/test_manage_badges.py
+++ b/tests/test_manage_badges.py
@@ -107,6 +107,33 @@ def test_manage_badges_filters_by_game(client, admin_user):
     assert new_badge.game_id == game1.id
 
 
+def test_manage_badges_uses_form_game_id(client, admin_user):
+    game = create_game("Game", admin_user)
+    login_as(client, admin_user)
+
+    data = {
+        "name": "Form Badge",
+        "description": "Desc",
+        "category": "none",
+        "game_id": str(game.id),
+        "image": (io.BytesIO(PNG_BYTES), "badge.png"),
+    }
+    resp = client.post(
+        "/badges/manage_badges",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 302
+
+    badge = Badge.query.filter_by(name="Form Badge").first()
+    assert badge is not None
+    assert badge.game_id == game.id
+
+    resp = client.get(f"/badges/manage_badges?game_id={game.id}")
+    html = resp.get_data(as_text=True)
+    assert "Form Badge" in html
+
+
 def test_get_badges_filters_by_game(client, admin_user):
     game1 = create_game("Game 1", admin_user)
     game2 = create_game("Game 2", admin_user)


### PR DESCRIPTION
## Summary
- Allow badge management route to read game id from form data
- Ensure form posts game id explicitly
- Add regression test for posting badge with form-only game id

## Testing
- `PYTHONPATH="$PWD" pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898d9241fbc832ba5c5fd06a5d26e1e