### PR TITLE
Require Humanify clearance for user registration

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -474,9 +474,15 @@ def logout():
 
 @auth_bp.route('/register', methods=['GET', 'POST'])
 def register():
+    """Register a new user."""
+    if request.method == "POST" and not current_app.config.get("TESTING"):
+        from app import humanify as humanify_ext
+
+        if not humanify_ext.has_valid_clearance_token:
+            return humanify_ext.challenge()
+
     form = RegistrationForm()
 
-                                    
     game_id = (request.args.get('game_id') or request.form.get('game_id') or None)
     custom_game_code = request.args.get('custom_game_code') or request.form.get('custom_game_code')
     quest_id = (request.args.get('quest_id') or request.form.get('quest_id') or None)


### PR DESCRIPTION
## Summary
- Challenge registration POSTs with Humanify unless running in testing mode
- Add docstring for registration endpoint

## Testing
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898e6b3b5a0832b8cfe3ddfb87e0f35