### PR TITLE
Handle empty numeric quest fields

### DIFF
--- a/app/quests.py
+++ b/app/quests.py
@@ -406,7 +406,7 @@ def update_quest(quest_id):
         )
         quest.badge_awarded = parse_int("badge_awarded", quest.badge_awarded)
     except ValueError as error:
-        return jsonify({"success": False, "message": str(error)}), 400
+        return jsonify({"success": False, "message": "Invalid input for quest field(s)."}), 400
 
     quest.enabled = data.get("enabled", quest.enabled)
     quest.is_sponsored = data.get("is_sponsored", quest.is_sponsored)

--- a/app/quests.py
+++ b/app/quests.py
@@ -389,9 +389,25 @@ def update_quest(quest_id):
     quest.title = sanitize_html(data.get("title", quest.title))
     quest.description = sanitize_html(data.get("description", quest.description))
     quest.tips = sanitize_html(data.get("tips", quest.tips))
-    quest.points = data.get("points", quest.points)
-    quest.completion_limit = data.get("completion_limit", quest.completion_limit)
-    quest.badge_awarded = data.get("badge_awarded", quest.badge_awarded)
+
+    def parse_int(field_name: str, current_value: int) -> int:
+        value = data.get(field_name)
+        if value in (None, ""):
+            return current_value
+        try:
+            return int(value)
+        except ValueError as err:  # pragma: no cover - defensive programming
+            raise ValueError(f"Invalid {field_name}") from err
+
+    try:
+        quest.points = parse_int("points", quest.points)
+        quest.completion_limit = parse_int(
+            "completion_limit", quest.completion_limit
+        )
+        quest.badge_awarded = parse_int("badge_awarded", quest.badge_awarded)
+    except ValueError as error:
+        return jsonify({"success": False, "message": str(error)}), 400
+
     quest.enabled = data.get("enabled", quest.enabled)
     quest.is_sponsored = data.get("is_sponsored", quest.is_sponsored)
     quest.category = sanitize_html(data.get("category", quest.category))

--- a/tests/test_quest_update_delete.py
+++ b/tests/test_quest_update_delete.py
@@ -90,6 +90,40 @@ def test_update_quest_returns_error_on_commit_failure(app, admin_user):
     assert data["success"] is False
 
 
+def test_update_quest_ignores_empty_numeric_fields(app, admin_user):
+    quest = setup_quest(admin_user)
+    quest.points = 5
+    quest.completion_limit = 2
+    quest.badge_awarded = 3
+    db.session.commit()
+
+    with app.test_request_context(
+        f"/quests/quest/{quest.id}/update",
+        method="POST",
+        json={
+            "title": "",
+            "description": "",
+            "tips": "",
+            "points": "",
+            "completion_limit": "",
+            "badge_awarded": "",
+            "category": "",
+            "verification_type": "",
+            "frequency": "",
+            "badge_option": "none",
+        },
+    ):
+        login_user(admin_user)
+        response = update_quest(quest.id)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert quest.points == 5
+    assert quest.completion_limit == 2
+    assert quest.badge_awarded == 3
+
+
 def test_delete_quest_returns_error_on_commit_failure(app, admin_user):
     quest = setup_quest(admin_user)
     with app.test_request_context(


### PR DESCRIPTION
## Summary
- ignore empty string values for quest points, completion limit, and badge award during updates
- add regression test for quest updates with blank numeric fields

## Testing
- `PYTHONPATH="$PWD" pytest tests/test_quest_update_delete.py::test_update_quest_ignores_empty_numeric_fields -vv`
- `PYTHONPATH="$PWD" pytest` *(fails: 19 failed, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6898f974ff18832ba20c74d2ecdb1a69