### PR TITLE
Enforce game-specific scoping for quests and badges

### DIFF
--- a/app/utils/quest_scoring.py
+++ b/app/utils/quest_scoring.py
@@ -78,6 +78,7 @@ def check_and_award_badges(user_id: int, quest_id: int, game_id: int) -> None:
     if (
         quest.badge_option in ("individual", "both")
         and quest.badge
+        and quest.badge.game_id == game_id
         and user_quest.completions >= quest.badge_awarded
     ):
         existing_award = ShoutBoardMessage.query.filter_by(
@@ -128,7 +129,9 @@ def check_and_award_badges(user_id: int, quest_id: int, game_id: int) -> None:
             )
         ]
         if len(completed_quests) == len(category_quests):
-            category_badges = Badge.query.filter_by(category=quest.category).all()
+            category_badges = Badge.query.filter_by(
+                category=quest.category, game_id=game_id
+            ).all()
             for badge in category_badges:
                 existing_award = ShoutBoardMessage.query.filter_by(
                     user_id=user_id,

--- a/tests/test_quest_update_delete.py
+++ b/tests/test_quest_update_delete.py
@@ -6,6 +6,7 @@ from app import create_app, db
 from app.models.game import Game
 from app.models.quest import Quest
 from app.models.user import User
+from app.models.badge import Badge
 from app.quests import update_quest, delete_quest
 from flask_login import login_user
 
@@ -122,6 +123,79 @@ def test_update_quest_ignores_empty_numeric_fields(app, admin_user):
     assert quest.points == 5
     assert quest.completion_limit == 2
     assert quest.badge_awarded == 3
+
+
+def test_update_quest_rejects_badge_from_other_game(app, admin_user):
+    quest = setup_quest(admin_user)
+    other_game = create_game("Other", admin_user.id)
+    other_game.admins.append(admin_user)
+    db.session.add(other_game)
+    db.session.commit()
+    other_badge = Badge(name="B", description="d", game_id=other_game.id)
+    db.session.add(other_badge)
+    db.session.commit()
+
+    with app.test_request_context(
+        f"/quests/quest/{quest.id}/update",
+        method="POST",
+        json={
+            "title": "",
+            "description": "",
+            "tips": "",
+            "points": "",
+            "completion_limit": "",
+            "badge_awarded": "",
+            "category": "",
+            "verification_type": "",
+            "frequency": "",
+            "badge_option": "individual",
+            "badge_id": other_badge.id,
+        },
+    ):
+        login_user(admin_user)
+        response, status = update_quest(quest.id)
+
+    assert status == 400
+    data = response.get_json()
+    assert data["success"] is False
+    assert quest.badge_id is None
+
+
+def test_update_quest_requires_game_admin(app, admin_user):
+    quest = setup_quest(admin_user)
+    other_admin = User(
+        username="other",
+        email="other@example.com",
+        is_admin=True,
+        license_agreed=True,
+        email_verified=True,
+    )
+    other_admin.set_password("pw")
+    db.session.add(other_admin)
+    db.session.commit()
+
+    with app.test_request_context(
+        f"/quests/quest/{quest.id}/update",
+        method="POST",
+        json={
+            "title": "",
+            "description": "",
+            "tips": "",
+            "points": "",
+            "completion_limit": "",
+            "badge_awarded": "",
+            "category": "",
+            "verification_type": "",
+            "frequency": "",
+            "badge_option": "none",
+        },
+    ):
+        login_user(other_admin)
+        response, status = update_quest(quest.id)
+
+    assert status == 403
+    data = response.get_json()
+    assert data["success"] is False
 
 
 def test_delete_quest_returns_error_on_commit_failure(app, admin_user):


### PR DESCRIPTION
## Summary
- guard badge creation and management so only admins of the badge's game can create or view categories
- ensure quests only reference badges from their own game and only game admins can update quests
- restrict badge awarding to badges and categories scoped to the current game

## Testing
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_68991d852d6c832bb070870034dfbd15