### PR TITLE
Schedule quarterly demo game creation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,6 +31,7 @@ from app.tasks import init_queue
 from app.activitypub_utils import ap_bp
 from app.ai import ai_bp
 from app.models import db
+from app.utils import generate_demo_game
 from .config import load_config
 from flask_wtf.csrf import CSRFProtect, CSRFError
 from datetime import timedelta
@@ -178,6 +179,7 @@ def create_app(config_overrides=None):
         db.create_all()
         create_super_admin(app)
         init_queue(app)
+        generate_demo_game()
 
                             
     app.register_blueprint(auth_bp, url_prefix="/auth")

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -3,9 +3,9 @@ from apscheduler.executors.pool import ThreadPoolExecutor
 from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.schedulers.base import STATE_RUNNING
 
-                                                     
 from app.utils.email_utils import check_and_send_liaison_emails
 from app.utils.calendar_utils import sync_google_calendar_events
+from app.utils import generate_demo_game
 
 def create_scheduler(app):
     scheduler = BackgroundScheduler(
@@ -23,6 +23,10 @@ def create_scheduler(app):
         with app.app_context():
             sync_google_calendar_events()
 
+    def _run_generate_demo():
+        with app.app_context():
+            generate_demo_game()
+
     scheduler.add_job(
         func=_run_check_and_send,
         trigger='cron',
@@ -37,8 +41,16 @@ def create_scheduler(app):
         id='calendar_sync_job',
         replace_existing=True,
     )
+    scheduler.add_job(
+        func=_run_generate_demo,
+        trigger='cron',
+        hour='0',
+        id='generate_demo_game_job',
+        replace_existing=True,
+    )
     app.logger.info("Scheduled job 'liaison_email_job'")
     app.logger.info("Scheduled job 'calendar_sync_job'")
+    app.logger.info("Scheduled job 'generate_demo_game_job'")
 
     scheduler.start()
     app.logger.info("APScheduler started")

--- a/tests/test_demo_game_generation.py
+++ b/tests/test_demo_game_generation.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch
+
+from app import create_app
+
+
+def test_generate_demo_game_called(monkeypatch):
+    with patch('app.__init__.generate_demo_game') as mock_gen, \
+         patch('app.__init__.init_queue') as mock_init_queue, \
+         patch('app.admin.create_super_admin'):
+        create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+        mock_gen.assert_called_once()


### PR DESCRIPTION
## Summary
- create quarterly demo games at startup
- schedule a nightly job to refresh the demo game each quarter
- add a regression test for demo game generation

## Testing
- `PYTHONPATH="$PWD" pytest` *(fails: ModuleNotFoundError: No module named 'pywebpush')*

------
https://chatgpt.com/codex/tasks/task_e_68997a53bb18832b89c5c210921bd0b7