### PR TITLE
Remove unreachable code from social media helper

### DIFF
--- a/app/social.py
+++ b/app/social.py
@@ -188,8 +188,6 @@ def get_instagram_permalink(media_id, access_token):
     else:
         raise Exception("Permalink not available yet.")
 
-    return None, "Failed to retrieve permalink after multiple attempts."
-
 
 def post_to_instagram(image_url, caption, user_id, access_token):
                                     


### PR DESCRIPTION
## Summary
- clean up `get_instagram_permalink` by dropping unreachable return

## Testing
- `PYTHONPATH="$PWD" pytest` *(fails: No module named 'flask')*
- `pip install -e .` *(fails: Building a package is not possible in non-package mode)*

------
https://chatgpt.com/codex/tasks/task_e_689af03294f8832bb768288b72e12179