### PR TITLE
Sanitize redirect targets to avoid open redirects

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -92,6 +92,19 @@ def test_get_login_opens_modal(client):
     assert params["next"] == ["/foo/bar"]
 
 
+def test_get_login_drops_unsafe_next(client):
+    resp = client.get("/auth/login?next=http://evil.com", follow_redirects=False)
+    assert resp.status_code == 302
+    loc = resp.headers["Location"]
+    parsed = urlparse(loc)
+    params = parse_qs(parsed.query)
+    from flask import url_for
+    with client.application.test_request_context():
+        expected_path = url_for("main.index")
+    assert parsed.path == expected_path
+    assert "next" not in params
+
+
 
 @pytest.mark.parametrize("headers,status_code,error,show_forgot", [
     ({}, 302, None, None),                                  

--- a/tests/test_auth_extra.py
+++ b/tests/test_auth_extra.py
@@ -69,7 +69,7 @@ def test_login_redirect_if_authenticated_next_unsafe(client, normal_user):
     login_as(client, normal_user)
     resp = client.get("/auth/login?next=http://evil.com", follow_redirects=False)
     assert resp.status_code == 302
-    expected = url_for_path(client.application, "main.index", show_login=0, next="http://evil.com", _external=False)
+    expected = url_for_path(client.application, "main.index", show_login=0, _external=False)
     assert resp.headers["Location"].endswith(expected)
 
 def test_unverified_email_non_ajax(client, app, normal_user):


### PR DESCRIPTION
## Summary
- validate redirect `next` parameters and strip unsafe URLs
- centralize `next` handling with `_next_params`
- cover unsafe `next` handling in login tests

## Testing
- `PYTHONPATH="$PWD" pytest`

------
https://chatgpt.com/codex/tasks/task_e_689af591579c832bb26bbd49616b8ea6