### PR TITLE
Hide badges card when game has no badges

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -214,6 +214,7 @@
     </div>
 
     {% if current_user.is_authenticated %}
+        {% if earned_badges or unearned_badges %}
         <div class="badge-bar-container">
         <h2>Available Badges</h2>
             <div class="badge-bar">
@@ -236,7 +237,7 @@
                 <div class="badge-name">{{ badge.name }}</div>
                 </div>
                 {% endfor %}
-        
+
                 {% for badge in unearned_badges %}
                 <div class="badge-item"
                     data-badge-id="{{ badge.id }}"
@@ -258,6 +259,7 @@
                 {% endfor %}
             </div>
         </div>
+        {% endif %}
         {% if has_joined %}
             <div class="badge-bar-container">
                 <h2>Available Quests</h2>

--- a/tests/test_index_badges.py
+++ b/tests/test_index_badges.py
@@ -1,0 +1,65 @@
+import pytest
+from datetime import datetime, timezone
+
+from app import create_app, db
+from app.models import Game, User
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        {
+            "TESTING": True,
+            "WTF_CSRF_ENABLED": False,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "MAIL_SERVER": None,
+        }
+    )
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login_as(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    with client.application.test_request_context():
+        from flask_login import login_user
+        login_user(user)
+
+
+def test_index_hides_badge_card_when_no_badges(client):
+    user = User(
+        username="u",
+        email="u@example.com",
+        license_agreed=True,
+        email_verified=True,
+    )
+    user.set_password("pw")
+    db.session.add(user)
+    db.session.commit()
+
+    game = Game(
+        title="G",
+        admin_id=user.id,
+        start_date=datetime.now(timezone.utc),
+        end_date=datetime.now(timezone.utc),
+    )
+    db.session.add(game)
+    db.session.commit()
+
+    login_as(client, user)
+    resp = client.get(f"/?game_id={game.id}")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "Available Badges" not in html


### PR DESCRIPTION
## Summary
- Only render the Available Badges card when a game has badges
- Test that the badges card is hidden for games without badges

## Testing
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba86a6f18832b9a789c7f42e5696a