### PR TITLE
refactor: clarify calendar ID parsing

### DIFF
--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -18,10 +18,12 @@ from app.models.quest import Quest
 
 
 def _parse_calendar_id(url: str) -> str | None:
+    """Return calendar ID from a Google calendar embed URL if present."""
     parsed = urlparse(url)
     qs = parse_qs(parsed.query)
-    if "src" in qs:
-        return qs["src"][0]
+    calendar_id = qs.get("src", [None])[0]
+    if calendar_id:
+        return calendar_id
     if parsed.path:
         return parsed.path.rstrip("/").split("/")[-1]
     return None


### PR DESCRIPTION
## Summary
- add docstring and simplify Google calendar ID extraction

## Testing
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fe03f0f88832b99f87ddabbd140ab