### PR TITLE
feat: simplify database error messages

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -13,7 +13,7 @@ from app.models.game import Game, Sponsor
 from app.models.quest import QuestSubmission
 from app.forms import SponsorForm
 from app.utils.file_uploads import save_sponsor_logo
-from app.utils import sanitize_html, get_int_param
+from app.utils import sanitize_html, get_int_param, format_db_error
 from app.decorators import require_admin, require_super_admin
 
 admin_bp = Blueprint('admin', __name__)
@@ -64,7 +64,10 @@ def create_super_admin(app):
             db.session.commit()
         except Exception as e:
             db.session.rollback()
-            current_app.logger.error(f"Error creating or updating super admin user: {e}")
+            current_app.logger.error(
+                "Error creating or updating super admin user: %s",
+                format_db_error(e),
+            )
 
 
 @admin_bp.route('/admin_dashboard')
@@ -160,7 +163,9 @@ def update_user(user_id):
         flash('User updated successfully.', 'success')
     except Exception as e:
         db.session.rollback()
-        current_app.logger.error(f"Error updating user: {e}")
+        current_app.logger.error(
+            "Error updating user: %s", format_db_error(e)
+        )
         flash('An error occurred while updating the user.', 'error')
     return redirect(url_for('admin.user_management'))
 
@@ -221,8 +226,8 @@ def edit_user(user_id):
             flash('User updated successfully.', 'success')
         except Exception as e:
             db.session.rollback()
-            logging.error("Error updating user: %s", e)
-            flash(f'Error updating user: {e}', 'error')
+            logging.error("Error updating user: %s", format_db_error(e))
+            flash(f"Error updating user: {format_db_error(e)}", 'error')
             return redirect(url_for('admin.edit_user', user_id=user.id))
 
         return redirect(url_for('admin.edit_user', user_id=user.id))
@@ -280,7 +285,9 @@ def delete_user(user_id):
         flash('User deleted successfully.', 'success')
     except Exception as e:
         db.session.rollback()
-        current_app.logger.error(f"Error deleting user: {e}")
+        current_app.logger.error(
+            "Error deleting user: %s", format_db_error(e)
+        )
         flash('An error occurred while deleting the user.', 'error')
     return redirect(url_for('admin.user_management'))
 
@@ -333,7 +340,7 @@ def delete_sponsor(sponsor_id):
         flash('Sponsor deleted successfully!', 'success')
     except Exception as e:
         db.session.rollback()
-        flash(f'Error occurred: {e}', 'danger')
+        flash(f"Error occurred: {format_db_error(e)}", 'danger')
     
                                                            
     return redirect(url_for('admin.manage_sponsors', game_id=game_id))
@@ -386,7 +393,10 @@ def manage_sponsors():
             flash('Sponsor added successfully!', 'success')
         except Exception as e:
             db.session.rollback()
-            flash(f'An error occurred while adding the sponsor: {e}', 'error')
+            flash(
+                f"An error occurred while adding the sponsor: {format_db_error(e)}",
+                'error',
+            )
         return redirect(url_for('admin.manage_sponsors', game_id=game_id))
 
     sponsors = Sponsor.query.filter_by(game_id=game_id).all() if game_id else Sponsor.query.all()

--- a/app/games.py
+++ b/app/games.py
@@ -31,7 +31,7 @@ from app.utils.file_uploads import (
     save_game_logo,
 )
 from app.utils.email_utils import send_social_media_liaison_email
-from app.utils import sanitize_html
+from app.utils import sanitize_html, format_db_error
 from io import BytesIO
 
 
@@ -198,7 +198,11 @@ def create_game():
             return redirect(url_for('admin.admin_dashboard'))
         except SQLAlchemyError as error:
             db.session.rollback()
-            flash(f'An error occurred while creating the game: {error}', 'error')
+            message = format_db_error(error)
+            flash(
+                f"An error occurred while creating the game: {message}",
+                "error",
+            )
     return render_template('create_game.html', title='Create Game', form=form,
         in_admin_dashboard=True)
 
@@ -253,7 +257,11 @@ def update_game(game_id):
             return redirect(url_for('main.index', game_id=game_id))
         except SQLAlchemyError as error:
             db.session.rollback()
-            flash(f'An error occurred while updating the game: {error}', 'error')
+            message = format_db_error(error)
+            flash(
+                f"An error occurred while updating the game: {message}",
+                "error",
+            )
     return render_template(
         'update_game.html',
         form=form,
@@ -298,10 +306,11 @@ def register_game(game_id):
         return redirect(url_for('main.index', game_id=game_id))
     except SQLAlchemyError as error:
         db.session.rollback()
+        message = format_db_error(error)
         current_app.logger.error(
-            f'Failed to register user for game {game_id}: {error}'
+            "Failed to register user for game %s: %s", game_id, message
         )
-        flash('An error occurred. Please try again.', 'error')
+        flash("An error occurred. Please try again.", "error")
     return redirect(url_for('main.index', game_id=game_id))
 
 
@@ -329,7 +338,12 @@ def delete_game(game_id):
 
     except SQLAlchemyError as error:
         db.session.rollback()
-        flash(f'An error occurred while deleting the game: {error}', 'error')
+        message = format_db_error(error)
+        current_app.logger.error("Failed to delete game %s: %s", game_id, message)
+        flash(
+            f"An error occurred while deleting the game: {message}",
+            "error",
+        )
 
     return redirect(url_for('admin.admin_dashboard'))
 

--- a/app/quests.py
+++ b/app/quests.py
@@ -30,7 +30,7 @@ from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.utils import secure_filename
 from app.forms import PhotoForm, QuestForm
 from app.social import post_to_social_media
-from app.utils import REQUEST_TIMEOUT, sanitize_html, get_int_param
+from app.utils import REQUEST_TIMEOUT, sanitize_html, get_int_param, format_db_error
 from app.utils.quest_scoring import (
     can_complete_quest,
     check_and_award_badges,
@@ -382,7 +382,9 @@ def submit_quest(quest_id):
             "activity": activity                                                             
         })
     except Exception as error:
-        current_app.logger.error("Quest submission failed: %s", error)
+        current_app.logger.error(
+            "Quest submission failed: %s", format_db_error(error)
+        )
         db.session.rollback()
         return jsonify({
             "success": False,
@@ -460,7 +462,9 @@ def update_quest(quest_id):
         return jsonify({"success": True, "message": "Quest updated successfully"})
     except Exception as error:
         db.session.rollback()
-        current_app.logger.error("Failed to update quest %s: %s", quest_id, error)
+        current_app.logger.error(
+            "Failed to update quest %s: %s", quest_id, format_db_error(error)
+        )
         return jsonify({
             "success": False,
             "message": "An unexpected error occurred while updating the quest.",
@@ -488,7 +492,7 @@ def delete_quest(quest_id):
     except Exception as error:
         db.session.rollback()
         current_app.logger.error(
-            "Failed to delete quest %s: %s", quest_id, error
+            "Failed to delete quest %s: %s", quest_id, format_db_error(error)
         )
         return jsonify({
             "success": False,
@@ -1210,7 +1214,11 @@ def clear_calendar_quests(game_id):
         db.session.commit()
         return jsonify({"success": True}), 200
     except Exception as exc:
-        current_app.logger.error("Failed to clear calendar quests for game %s: %s", game_id, exc)
+        current_app.logger.error(
+            "Failed to clear calendar quests for game %s: %s",
+            game_id,
+            format_db_error(exc),
+        )
         db.session.rollback()
         return jsonify({"success": False, "message": "Failed to clear quests."}), 500
 

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -97,6 +97,20 @@ def get_int_param(name: str, *, source=None, default: int | None = None) -> int 
     except (TypeError, ValueError):
         return default
 
+
+def format_db_error(error: Exception) -> str:
+    """Return a concise description for a database error."""
+    orig = getattr(error, "orig", None)
+    if orig is None:
+        return str(error)
+    diag = getattr(orig, "diag", None)
+    primary = getattr(diag, "message_primary", None) if diag else None
+    detail = getattr(diag, "message_detail", None) if diag else None
+    message = primary or str(orig)
+    if detail:
+        message = f"{message}: {detail}"
+    return message
+
 # ----------------------------------------------------------------------------
 # Misc database helpers
 # ----------------------------------------------------------------------------

--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -11,6 +11,8 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from sqlalchemy.exc import SQLAlchemyError
 
+from app.utils import format_db_error
+
 from app.constants import UTC
 from app.models import db
 from app.models.game import Game
@@ -146,5 +148,7 @@ def sync_google_calendar_events() -> None:
     try:
         db.session.commit()
     except SQLAlchemyError as exc:
-        current_app.logger.error("Calendar sync commit failed: %s", exc)
+        current_app.logger.error(
+            "Calendar sync commit failed: %s", format_db_error(exc)
+        )
         db.session.rollback()

--- a/app/utils/email_utils.py
+++ b/app/utils/email_utils.py
@@ -11,6 +11,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from flask import current_app, url_for
 from sqlalchemy.exc import SQLAlchemyError, OperationalError
+from app.utils import format_db_error
 from textwrap import dedent
 from PIL import Image
 
@@ -73,7 +74,9 @@ def send_social_media_liaison_email(
         game = db.session.get(Game, game_id)
     except Exception as e:
         current_app.logger.error(
-            "Database error while fetching Game id=%s: %s", game_id, e
+            "Database error while fetching Game id=%s: %s",
+            game_id,
+            format_db_error(e),
         )
         return False
 
@@ -103,7 +106,9 @@ def send_social_media_liaison_email(
         )
     except Exception as e:
         current_app.logger.error(
-            "Database error fetching submissions for game_id=%s: %s", game_id, e
+            "Database error fetching submissions for game_id=%s: %s",
+            game_id,
+            format_db_error(e),
         )
         return False
 
@@ -248,7 +253,7 @@ def send_social_media_liaison_email(
             current_app.logger.error(
                 "Email sent, but failed to update last_social_media_email_sent for game_id=%s: %s",
                 game_id,
-                db_err,
+                format_db_error(db_err),
             )
         return True
     current_app.logger.warning(


### PR DESCRIPTION
## Summary
- add `format_db_error` helper to condense SQLAlchemy errors
- use formatted messages across views and utilities

## Testing
- `pip install -e .` *(fails: Building a package is not possible in non-package mode)*
- `PYTHONPATH="$PWD" pytest` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a021ef0af4832b8ad31359586ebe90