### PR TITLE
Log cloud storage errors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -805,8 +805,10 @@ def _coerce_to_list(raw: Any) -> List[str]:
             loaded = json.loads(raw)
             if isinstance(loaded, list):
                 return loaded
-        except json.JSONDecodeError:
-            pass
+        except json.JSONDecodeError as exc:
+            current_app.logger.debug(
+                "Failed to decode list from JSON: %s", exc
+            )
 
                                           
         return [item.strip() for item in raw.split(',') if item.strip()]


### PR DESCRIPTION
## Summary
- add explicit Google Cloud error handling in file upload helpers
- log JSON parsing issues when coercing string lists

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a11170f4a0832b820906d2413cf512