### PR TITLE
Add docstrings for app factory and update developer docs

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -81,7 +81,8 @@ The project is organized as follows:
 
 ### Important Files
 
-- **`app/__init__.py`**: Initializes the Flask application and registers blueprints.
+- **`app/__init__.py`**: Provides the `create_app` factory, loads configuration via `load_config`,
+  overrides `url_for` for testing, initializes extensions, and registers blueprints.
 - **`app/models.py`**: Defines the database models.
 - **`app/forms.py`**: Defines the forms used in the application.
 - **`app/utils/`**: Package of utility modules used across the application.


### PR DESCRIPTION
## Summary
- document `_url_for` helper to clarify testing behavior
- describe configuration and blueprint registration in `create_app`
- expand developer docs for application factory and URL override

## Testing
- `pip install -e .` (fails: Building a package is not possible in non-package mode)
- `PYTHONPATH="$PWD" pytest` (fails: ModuleNotFoundError: No module named 'flask')

------
https://chatgpt.com/codex/tasks/task_e_68a113152d90832ba12c1dbceb569936