### PR TITLE
Refactor profile routes for safer exception handling

### DIFF
--- a/app/profile.py
+++ b/app/profile.py
@@ -1,10 +1,11 @@
 import json
 import requests
+from requests.exceptions import RequestException
 from .utils import REQUEST_TIMEOUT, sanitize_html
 from flask import Blueprint, jsonify, request, current_app
 from flask_login import current_user, login_required
 from .models import db, ProfileWallMessage, User, Notification
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from app.activitypub_utils import sign_activitypub_request
 from urllib.parse import urlparse
 from threading import Thread
@@ -16,35 +17,34 @@ def _deliver_follow_activity(app, actor_url, activity, sender_id):
     """Background thread: fetch target’s actor doc and POST the activity."""
     with app.app_context():
         try:
-
             sender = db.session.get(User, sender_id)
             sender.ensure_activitypub_actor()
-
             doc = requests.get(actor_url, timeout=REQUEST_TIMEOUT).json()
             inbox = doc.get("inbox")
             if inbox:
-                hdrs = sign_activitypub_request(sender, 'POST', inbox, json.dumps(activity))
+                hdrs = sign_activitypub_request(sender, "POST", inbox, json.dumps(activity))
                 requests.post(
                     inbox,
                     json=activity,
                     headers=hdrs,
                     timeout=REQUEST_TIMEOUT,
                 )
-        except Exception as e:
+        except (SQLAlchemyError, RequestException, ValueError) as exc:
             app.logger.error(
-                "Failed to deliver ActivityPub activity to %s: %s", actor_url, e
+                "Failed to deliver ActivityPub activity to %s: %s", actor_url, exc
             )
 
 
 @profile_bp.route('/<int:user_id>/messages', methods=['POST'])
 @login_required
 def post_profile_message(user_id):
+    """Post a new message on a user's profile wall."""
     User.query.get_or_404(user_id)
     data = request.get_json()
-    content = sanitize_html(data.get('content'))
+    content = sanitize_html(data.get("content"))
 
     if not content:
-        return jsonify({'error': 'Content is required.'}), 400
+        return jsonify({"error": "Content is required."}), 400
 
     message = ProfileWallMessage(
         content=content,
@@ -60,50 +60,58 @@ def post_profile_message(user_id):
     for fid in follower_ids:
         notif = Notification(
             user_id=fid,
-            type='profile_message',
+            type="profile_message",
             payload={
-                'profile_message_id': message.id,
-                'from_user_id': current_user.id,
-                'from_user_name': current_user.display_name or current_user.username,
-                'profile_user_id': user_id,
-                'content': message.content
-            }
+                "profile_message_id": message.id,
+                "from_user_id": current_user.id,
+                "from_user_name": current_user.display_name or current_user.username,
+                "profile_user_id": user_id,
+                "content": message.content,
+            },
         )
         db.session.add(notif)
     db.session.commit()
 
     return jsonify({
-        'success': 'Message posted successfully.',
-        'message': {
-            'id': message.id,
-            'content': message.content,
-            'timestamp': message.timestamp,
-            'author_id': message.author_id,
-            'author': {'username': message.author.username}
-        }
+        "success": "Message posted successfully.",
+        "message": {
+            "id": message.id,
+            "content": message.content,
+            "timestamp": message.timestamp,
+            "author_id": message.author_id,
+            "author": {"username": message.author.username},
+        },
     }), 201
 
 
 @profile_bp.route('/<int:user_id>/messages/<int:message_id>/delete', methods=['POST'])
 @login_required
 def delete_message(user_id, message_id):
+    """Delete a message from a user's profile wall."""
     message = ProfileWallMessage.query.get_or_404(message_id)
-    
+
     if message.user_id != current_user.id and not current_user.is_admin:
-        return jsonify({'error': 'You do not have permission to delete this message.'}), 403
-    
+        return (
+            jsonify({"error": "You do not have permission to delete this message."}),
+            403,
+        )
+
     try:
         db.session.delete(message)
         db.session.commit()
-        return jsonify({'success': True}), 200
-    except IntegrityError:
+        return jsonify({"success": True}), 200
+    except IntegrityError as exc:
         db.session.rollback()
-        return
+        current_app.logger.error(
+            "Failed to delete profile message %s: %s", message_id, exc
+        )
+        return jsonify({"error": "Database error occurred"}), 500
 
 
 @profile_bp.route('/<int:user_id>/messages/<int:message_id>/reply', methods=['POST'])
 @login_required
 def post_reply(user_id, message_id):
+    """Reply to a profile wall message."""
     user = User.query.get_or_404(user_id)
     message = ProfileWallMessage.query.get_or_404(message_id)
 
@@ -117,12 +125,12 @@ def post_reply(user_id, message_id):
             == db.session.get(ProfileWallMessage, message.parent_id).author_id
         )
     ):
-        return jsonify({'error': 'You are not authorized to reply to messages on this profile.'}), 403
+        return jsonify({"error": "You are not authorized to reply to messages on this profile."}), 403
 
     data = request.get_json()
-    content = sanitize_html(data.get('content'))
+    content = sanitize_html(data.get("content"))
     if not content:
-        return jsonify({'error': 'Content is required.'}), 400
+        return jsonify({"error": "Content is required."}), 400
 
     reply = ProfileWallMessage(
         content=content,
@@ -139,68 +147,74 @@ def post_reply(user_id, message_id):
     for fid in follower_ids:
         notif = Notification(
             user_id=fid,
-            type='profile_reply',
+            type="profile_reply",
             payload={
-                'reply_id': reply.id,
-                'from_user_id': current_user.id,
-                'from_user_name': current_user.display_name or current_user.username,
-                'profile_user_id': user_id,
-                'content': reply.content
-            }
+                "reply_id": reply.id,
+                "from_user_id": current_user.id,
+                "from_user_name": current_user.display_name or current_user.username,
+                "profile_user_id": user_id,
+                "content": reply.content,
+            },
         )
         db.session.add(notif)
     db.session.commit()
 
     return jsonify({
-        'success': 'Reply posted successfully.',
-        'reply': {
-            'id': reply.id,
-            'content': reply.content,
-            'timestamp': reply.timestamp,
-            'author_id': reply.author_id,
-            'author': {'username': reply.author.username},
-            'parent_id': reply.parent_id
-        }
+        "success": "Reply posted successfully.",
+        "reply": {
+            "id": reply.id,
+            "content": reply.content,
+            "timestamp": reply.timestamp,
+            "author_id": reply.author_id,
+            "author": {"username": reply.author.username},
+            "parent_id": reply.parent_id,
+        },
     }), 201
 
 
 @profile_bp.route('/<int:user_id>/messages/<int:message_id>/edit', methods=['POST'])
 @login_required
 def edit_message(user_id, message_id):
+    """Edit an existing profile message."""
     message = ProfileWallMessage.query.get_or_404(message_id)
-    
+
     if message.author_id != current_user.id:
-        return jsonify({'error': 'Unauthorized access'}), 403
+        return jsonify({"error": "Unauthorized access"}), 403
 
     data = request.get_json()
-    new_content = sanitize_html(data.get('content'))
+    new_content = sanitize_html(data.get("content"))
 
     if not new_content:
-        return jsonify({'error': 'Content is required.'}), 400
+        return jsonify({"error": "Content is required."}), 400
 
     message.content = new_content
 
     try:
         db.session.commit()
-        return jsonify({'message': 'Message updated successfully'})
-    except Exception:
+        return jsonify({"message": "Message updated successfully"})
+    except SQLAlchemyError as exc:
         db.session.rollback()
-        return
+        current_app.logger.error(
+            "Failed to update profile message %s: %s", message_id, exc
+        )
+        return jsonify({"error": "Database error occurred"}), 500
 
 
 def is_local_actor(actor_url):
+    """Return True if the actor URL belongs to the local server."""
     host = urlparse(actor_url).netloc
-    locals = {
-        current_app.config['LOCAL_DOMAIN'],
-        '127.0.0.1:5000',
-        'localhost:5000',
+    local_hosts = {
+        current_app.config["LOCAL_DOMAIN"],
+        "127.0.0.1:5000",
+        "localhost:5000",
     }
-    return host in locals
+    return host in local_hosts
 
 
 @profile_bp.route('/<string:username>/follow', methods=['POST'])
 @login_required
 def follow_user(username):
+    """Follow a user and deliver the ActivityPub follow activity."""
     target = User.query.filter_by(username=username).first_or_404()
 
                        
@@ -221,24 +235,28 @@ def follow_user(username):
     db.session.commit()
 
     follower_name = current_user.display_name or current_user.username
-    db.session.add(Notification(
-        user_id = target.id,
-        type    = 'followed_by',
-        payload = {
-            'follower_id':   current_user.id,
-            'follower_name': follower_name
-        }
-    ))
+    db.session.add(
+        Notification(
+            user_id=target.id,
+            type="followed_by",
+            payload={
+                "follower_id": current_user.id,
+                "follower_name": follower_name,
+            },
+        )
+    )
     db.session.commit()
 
-    db.session.add(Notification(
-        user_id = current_user.id,
-        type    = 'follow',
-        payload = {
-            'from_user_id':   target.id,
-            'from_user_name': target.display_name or target.username
-        }
-    ))
+    db.session.add(
+        Notification(
+            user_id=current_user.id,
+            type="follow",
+            payload={
+                "from_user_id": target.id,
+                "from_user_name": target.display_name or target.username,
+            },
+        )
+    )
     db.session.commit()
 
                                     
@@ -266,6 +284,7 @@ def follow_user(username):
 @profile_bp.route('/<string:username>/unfollow', methods=['POST'])
 @login_required
 def unfollow_user(username):
+    """Unfollow a user and send the corresponding ActivityPub undo activity."""
     target = User.query.filter_by(username=username).first_or_404()
 
                          


### PR DESCRIPTION
## Summary
- Replace blanket exceptions in ActivityPub delivery with targeted SQLAlchemy, request, and JSON error handling
- Add docstrings and explicit JSON error responses for profile message delete/edit
- Avoid swallowing database failures by logging errors and returning 500 responses

## Testing
- `PYTHONPATH="$PWD" pytest` *(fails: ModuleNotFoundError: No module named 'html_sanitizer')*

------
https://chatgpt.com/codex/tasks/task_e_68a11fc08c3c832bbf92a48caface4c3