### PR TITLE
Refactor broad exception handling

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import csv
 import os
-from html_sanitizer import Sanitizer
-from flask import current_app, request, url_for
-from urllib.parse import urlparse, urlunparse
 from datetime import datetime, timedelta
+from urllib.parse import urlparse, urlunparse
+
+from flask import current_app, request, url_for
+from html_sanitizer import Sanitizer
+from sqlalchemy.exc import SQLAlchemyError
 
 from ..models import (
     db,
@@ -224,7 +226,7 @@ def generate_demo_game() -> Game | None:
         )
         db.session.add(pinned_message)
         db.session.commit()
-    except Exception as exc:  # pragma: no cover - log and rollback
+    except SQLAlchemyError as exc:  # pragma: no cover - log and rollback
         db.session.rollback()
         current_app.logger.error("Failed to pin demo message: %s", exc)
 
@@ -276,7 +278,7 @@ def import_quests_and_badges_from_csv(game_id: int, csv_path: str) -> None:
                 )
                 db.session.add(quest)
             db.session.commit()
-    except Exception as exc:  # pragma: no cover - log and rollback
+    except (OSError, SQLAlchemyError) as exc:  # pragma: no cover - log and rollback
         db.session.rollback()
         current_app.logger.error(
             "Failed to import quests and badges from %s: %s", csv_path, exc

--- a/app/utils/email_utils.py
+++ b/app/utils/email_utils.py
@@ -64,7 +64,7 @@ def send_email(
             smtp_conn.sendmail(msg_root["From"], [to], msg_root.as_string())
         current_app.logger.info("Email sent successfully to %s.", to)
         return True
-    except Exception as exc:
+    except (smtplib.SMTPException, OSError) as exc:
         current_app.logger.error("Failed to send email: %s", exc)
         return False
 
@@ -77,7 +77,7 @@ def send_social_media_liaison_email(
     """Send a digest of recent quest submissions to a game's liaison."""
     try:
         game = db.session.get(Game, game_id)
-    except Exception as e:
+    except SQLAlchemyError as e:
         current_app.logger.error(
             "Database error while fetching Game id=%s: %s",
             game_id,
@@ -109,7 +109,7 @@ def send_social_media_liaison_email(
             .order_by(QuestSubmission.timestamp.asc())
             .all()
         )
-    except Exception as e:
+    except SQLAlchemyError as e:
         current_app.logger.error(
             "Database error fetching submissions for game_id=%s: %s",
             game_id,
@@ -215,7 +215,7 @@ def send_social_media_liaison_email(
                         html_parts.append(
                             f'<img src="{public_url}" alt="submission image"><br>'
                         )
-                    except Exception as ue:
+                    except RuntimeError as ue:
                         current_app.logger.error(
                             "Failed to generate public URL for image '%s': %s",
                             rel_path,
@@ -254,7 +254,7 @@ def send_social_media_liaison_email(
             current_app.logger.info(
                 "Sent social media email for game_id=%s to %s.", game_id, liaison_email
             )
-        except Exception as db_err:
+        except SQLAlchemyError as db_err:
             current_app.logger.error(
                 "Email sent, but failed to update last_social_media_email_sent for game_id=%s: %s",
                 game_id,


### PR DESCRIPTION
## Summary
- refine email sending to catch specific SMTP and OS errors
- replace generic Exception handlers with SQLAlchemyError and RuntimeError where appropriate
- clean up utility imports and handle file/database errors more precisely

## Testing
- `PYTHONPATH="$PWD" pytest` *(fails: ModuleNotFoundError: No module named 'google')*


------
https://chatgpt.com/codex/tasks/task_e_68a11fc08c3c832bbf92a48caface4c3