### PR TITLE
Fix quest update edge cases

### DIFF
--- a/app/quests.py
+++ b/app/quests.py
@@ -478,6 +478,11 @@ def update_quest(quest_id):
 
     try:
         db.session.commit()
+        if (
+            quest.calendar_event_start
+            and quest.calendar_event_start.tzinfo is None
+        ):
+            quest.calendar_event_start = quest.calendar_event_start.replace(tzinfo=UTC)
         return jsonify({"success": True, "message": "Quest updated successfully"})
     except Exception as error:
         db.session.rollback()

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -66,7 +66,10 @@ def safe_url_for(*args, **kwargs):
     return url
 
 
-def sanitize_html(html_content: str) -> str:
+def sanitize_html(html_content: str | None) -> str | None:
+    """Sanitize HTML content or return ``None`` for blank values."""
+    if html_content is None:
+        return None
     return SANITIZER.sanitize(html_content)
 
 


### PR DESCRIPTION
## Summary
- allow `sanitize_html` to accept `None`
- keep quest calendar start times timezone-aware

## Testing
- `PYTHONPATH="$PWD" pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a121457e64832b8073886a4a3a5b31