### PR TITLE
Remove silent pass statements

### DIFF
--- a/app/activitypub_utils.py
+++ b/app/activitypub_utils.py
@@ -345,8 +345,8 @@ def inbox(username):
                         quest_id=quest_id
                     ))
                     db.session.commit()
-            except ValueError:
-                pass
+            except ValueError as exc:
+                current_app.logger.warning("Invalid quest id in Like activity: %s", exc)
         return ('', 202)
 
                                             
@@ -367,8 +367,8 @@ def inbox(username):
                         }
                     ))
                     db.session.commit()
-            except ValueError:
-                pass
+            except ValueError as exc:
+                current_app.logger.warning("Invalid submission id in Announce activity: %s", exc)
         return ('', 202)
 
                                                    
@@ -386,8 +386,8 @@ def inbox(username):
                     if like:
                         db.session.delete(like)
                         db.session.commit()
-                except ValueError:
-                    pass
+                except ValueError as exc:
+                    current_app.logger.warning("Invalid quest id in Undo activity: %s", exc)
             return ('', 202)
         if obj.get('type') == 'Follow' and obj.get('object') == user.activitypub_id:
             if sender in user.followers:

--- a/app/utils/file_uploads.py
+++ b/app/utils/file_uploads.py
@@ -170,8 +170,8 @@ def save_image_file(
             corrected = correct_image_orientation(img)
             if corrected is not img:
                 corrected.save(file_path)
-    except UnidentifiedImageError:
-        pass
+    except UnidentifiedImageError as exc:
+        current_app.logger.warning("Invalid image file uploaded: %s", exc)
 
     gcs_url = _upload_to_gcs(file_path, os.path.join(subpath, filename), content_type=image_file.mimetype)
     if old_filename:
@@ -403,8 +403,8 @@ def delete_media_file(path: str | None) -> None:
     if os.path.exists(full_path):
         try:
             os.remove(full_path)
-        except OSError:
-            pass
+        except OSError as exc:
+            current_app.logger.warning("Failed to delete media file %s: %s", full_path, exc)
 
 
 def save_sponsor_logo(image_file, old_filename=None):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,19 +19,13 @@ def app():
     ctx.push()
 
                         
-    try:
-        db.drop_all()
-    except Exception:
-        pass
+    db.drop_all()
     db.create_all()
 
     yield app
 
     db.session.remove()
-    try:
-        db.drop_all()
-    except Exception:
-        pass
+    db.drop_all()
     ctx.pop()
 
 @pytest.fixture

--- a/tests/test_auth_extra.py
+++ b/tests/test_auth_extra.py
@@ -18,19 +18,13 @@ def app():
     ctx.push()
 
                         
-    try:
-        db.drop_all()
-    except Exception:
-        pass
+    db.drop_all()
     db.create_all()
 
     yield app
 
     db.session.remove()
-    try:
-        db.drop_all()
-    except Exception:
-        pass
+    db.drop_all()
     ctx.pop()
 
 @pytest.fixture

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -50,7 +50,7 @@ def test_calendar_sync_creates_photo_quest(app, monkeypatch, tmp_path):
             def patch(self, **_):
                 class X:
                     def execute(self):
-                        pass
+                        return None
                 return X()
             def execute(self):
                 return {
@@ -107,8 +107,7 @@ def test_calendar_sync_strips_link_from_description(app, monkeypatch, tmp_path):
             def patch(self, **_):
                 class X:
                     def execute(self):
-                        pass
-
+                        return None
                 return X()
 
             def execute(self):
@@ -163,8 +162,7 @@ def test_calendar_sync_relative_service_path(app, monkeypatch, tmp_path):
             def patch(self, **_):
                 class X:
                     def execute(self):
-                        pass
-
+                        return None
                 return X()
 
             def execute(self):

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -19,19 +19,13 @@ def app():
     ctx.push()
 
                         
-    try:
-        db.drop_all()
-    except Exception:
-        pass
+    db.drop_all()
     db.create_all()
 
     yield app
 
     db.session.remove()
-    try:
-        db.drop_all()
-    except Exception:
-        pass
+    db.drop_all()
     ctx.pop()
 
 @pytest.fixture

--- a/tests/test_registration_extra.py
+++ b/tests/test_registration_extra.py
@@ -13,19 +13,13 @@ def app():
     ctx.push()
 
                         
-    try:
-        db.drop_all()
-    except Exception:
-        pass
+    db.drop_all()
     db.create_all()
 
     yield app
 
     db.session.remove()
-    try:
-        db.drop_all()
-    except Exception:
-        pass
+    db.drop_all()
     ctx.pop()
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- replace silent `pass` blocks with logging in ActivityPub utilities and file uploads
- clean test fixtures and stubs to avoid swallowing errors

## Testing
- `PYTHONPATH="$PWD" pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a121457e64832b8073886a4a3a5b31