### PR TITLE
Handle null HTML and preserve quest calendar timezone

### DIFF
--- a/app/quests.py
+++ b/app/quests.py
@@ -478,6 +478,13 @@ def update_quest(quest_id):
 
     try:
         db.session.commit()
+        if (
+            quest.calendar_event_start
+            and quest.calendar_event_start.tzinfo is None
+        ):
+            quest.calendar_event_start = quest.calendar_event_start.replace(
+                tzinfo=UTC
+            )
         return jsonify({"success": True, "message": "Quest updated successfully"})
     except Exception as error:
         db.session.rollback()

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -66,7 +66,16 @@ def safe_url_for(*args, **kwargs):
     return url
 
 
-def sanitize_html(html_content: str) -> str:
+def sanitize_html(html_content: str | None) -> str | None:
+    """Return sanitized HTML or ``None`` for empty input.
+
+    Parameters
+    ----------
+    html_content:
+        Raw HTML content which may be ``None``.
+    """
+    if html_content is None:
+        return None
     return SANITIZER.sanitize(html_content)
 
 


### PR DESCRIPTION
## Summary
- Avoid sanitizer errors on missing optional fields by returning `None` when HTML content is absent
- Ensure calendar event start retains UTC timezone after quest updates

## Testing
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a121457e64832b8073886a4a3a5b31