### PR TITLE
Add OpenAPI spec and secure API docs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -207,6 +207,10 @@ def create_app(config_overrides=None):
     app.register_blueprint(push_bp, url_prefix="/push")
     app.register_blueprint(webfinger_bp)
     app.register_blueprint(main_bp)
+    if app.config.get("ENV") != "production":
+        from app.docs import docs_bp
+
+        app.register_blueprint(docs_bp)
 
     csrf.exempt(ap_bp)
     login_manager.login_view = "auth.login"

--- a/app/docs.py
+++ b/app/docs.py
@@ -1,0 +1,37 @@
+import os
+
+from flask import Blueprint, current_app, send_from_directory
+from flask_login import login_required
+
+
+docs_bp = Blueprint("docs", __name__, url_prefix="/docs")
+
+
+@docs_bp.route("/openapi.yaml")
+@login_required
+def openapi_yaml():
+    """Return the OpenAPI specification."""
+    docs_path = os.path.join(current_app.root_path, "..", "docs")
+    return send_from_directory(docs_path, "openapi.yaml")
+
+
+@docs_bp.route("/")
+@login_required
+def redoc():
+    """Serve the Redoc API documentation."""
+    return (
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>API Docs</title>
+            <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+        </head>
+        <body>
+            <redoc spec-url="/docs/openapi.yaml"></redoc>
+        </body>
+        </html>
+        """,
+        200,
+        {"Content-Type": "text/html"},
+    )

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,16 @@
+# API
+
+QuestByCycle exposes a small public JSON API documented using OpenAPI.
+
+## Documentation
+
+In non-production environments the API specification can be viewed at `/docs`. The page requires an authenticated user and uses Redoc for a read-only display.
+
+## Specification
+
+The OpenAPI document lives in `docs/openapi.yaml` and describes the following endpoints:
+
+- `GET /games/get_game/{game_id}` – fetch details about a game.
+- `GET /games/get_game_points/{game_id}` – retrieve a game's total points and goal.
+- `GET /manifest.json` – dynamic PWA manifest.
+- `GET /.well-known/assetlinks.json` – Android digital asset links.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,129 @@
+openapi: 3.0.3
+info:
+  title: QuestByCycle API
+  version: "1.0.0"
+paths:
+  /games/get_game/{game_id}:
+    get:
+      summary: Get a game
+      parameters:
+        - name: game_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Serialized game
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Game'
+        "404":
+          description: Game not found
+  /games/get_game_points/{game_id}:
+    get:
+      summary: Get total points for a game
+      parameters:
+        - name: game_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Points and goal
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_game_points:
+                    type: integer
+                  game_goal:
+                    type: integer
+        "401":
+          description: Unauthorized
+        "404":
+          description: Game not found
+  /manifest.json:
+    get:
+      summary: Retrieve the PWA manifest
+      responses:
+        "200":
+          description: Manifest data
+          content:
+            application/json:
+              schema:
+                type: object
+  /.well-known/assetlinks.json:
+    get:
+      summary: Retrieve Android asset links
+      responses:
+        "200":
+          description: Asset link definitions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    relation:
+                      type: array
+                      items:
+                        type: string
+                    target:
+                      type: object
+                      properties:
+                        namespace:
+                          type: string
+                        package_name:
+                          type: string
+                        sha256_cert_fingerprints:
+                          type: array
+                          items:
+                            type: string
+components:
+  schemas:
+    Game:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        game_goal:
+          type: integer
+          nullable: true
+        is_public:
+          type: boolean
+        allow_joins:
+          type: boolean
+        calendar_url:
+          type: string
+          nullable: true
+        calendar_service_json_path:
+          type: string
+          nullable: true
+        logo:
+          type: string
+          nullable: true
+        logo_url:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true

--- a/tests/test_docs_route.py
+++ b/tests/test_docs_route.py
@@ -1,0 +1,12 @@
+from app import create_app
+
+
+def test_docs_route_only_in_non_production():
+    app_prod = create_app({"TESTING": True, "ENV": "production"})
+    client_prod = app_prod.test_client()
+    assert client_prod.get("/docs/").status_code == 404
+
+    app_dev = create_app({"TESTING": True, "ENV": "development"})
+    client_dev = app_dev.test_client()
+    resp = client_dev.get("/docs/")
+    assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- add static OpenAPI 3 spec for public JSON endpoints
- expose read-only Redoc viewer behind auth in non-production
- document API and add tests for docs route access

## Testing
- `pip install flask flask-wtf flask-sqlalchemy flask-login sqlalchemy psycopg2-binary qrcode openai pywebpush python-dotenv rsa html-sanitizer requests-oauthlib redis rq google-cloud-storage google-api-python-client flask-humanify`
- `pip install pyjwt`
- `pip install Pillow`
- `PYTHONPATH="$PWD" pytest` *(fails: 11 failed, 35 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a12549ca4c832ba8730fe03df3f724