### PR TITLE
Add single-command dev startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: dev
+
+dev:
+	./scripts/dev.sh

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ For automated provisioning details see [docs/INFRASTRUCTURE.md](docs/INFRASTRUCT
    npm run build
    ```
 
+   Start the development environment with one command:
+   ```bash
+   make dev
+   ```
+   This simultaneously launches the Flask server, Vite dev server, and the RQ worker.
+
 
 #### RAM Allocation
   Allocate Swap on low ram systems:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start Flask development server, Vite dev server, and RQ worker concurrently.
+# Use trap to ensure all child processes exit when this script does.
+trap 'kill 0' EXIT
+
+# Flask backend with reloader and debugger
+poetry run flask --app wsgi:app --debug run &
+
+# Vite frontend dev server
+npm run dev &
+
+# Background task worker
+poetry run rqworker &
+
+wait


### PR DESCRIPTION
## Summary
- Add `scripts/dev.sh` to launch Flask, Vite dev server, and RQ worker together
- Provide `Makefile` `dev` target for unified startup
- Document the `make dev` command in README

## Testing
- `PYTHONPATH="$PWD" poetry run pytest` *(fails: Could not parse SQLAlchemy URL from given URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a126125240832b88081a9dac44996f