### PR TITLE
feat: add Google OAuth login option

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -148,6 +148,8 @@ def create_app(config_overrides=None):
         "FACEBOOK_PAGE_ID": inscopeconfig.social.facebook_page_id,
         "INSTAGRAM_ACCESS_TOKEN": inscopeconfig.social.instagram_access_token,
         "INSTAGRAM_USER_ID": inscopeconfig.social.instagram_user_id,
+        "GOOGLE_CLIENT_ID": inscopeconfig.social.google_client_id,
+        "GOOGLE_CLIENT_SECRET": inscopeconfig.social.google_client_secret,
         "TWA_SHA256_FINGERPRINT": inscopeconfig.twa.SHA256_CERT_FINGERPRINT,
         "WTF_CSRF_ENABLED": not inscopeconfig.flask.DEBUG,
         "VAPID_PUBLIC_KEY":  inscopeconfig.push.VAPID_PUBLIC_KEY,

--- a/app/auth.py
+++ b/app/auth.py
@@ -7,6 +7,7 @@ import uuid
 import requests
 from datetime import datetime
 from urllib.parse import urlparse, urlencode
+from requests_oauthlib import OAuth2Session
 
 from flask import (
     Blueprint,
@@ -358,6 +359,112 @@ def mastodon_callback():
             flash("Account created and logged in via Mastodon. You will federate using your Mastodon identity.", "success")
     
     return redirect(url_for('main.index'))
+
+
+@auth_bp.route("/login/google")
+def google_login():
+    """Start the Google OAuth2 login flow."""
+    client_id = current_app.config.get("GOOGLE_CLIENT_ID")
+    client_secret = current_app.config.get("GOOGLE_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        flash("Google OAuth is not configured.", "danger")
+        return redirect(url_for("auth.login"))
+
+    redirect_uri = safe_url_for("auth.google_callback", _external=True)
+    oauth = OAuth2Session(
+        client_id,
+        redirect_uri=redirect_uri,
+        scope=["openid", "email", "profile"],
+    )
+    authorization_url, state = oauth.authorization_url(
+        "https://accounts.google.com/o/oauth2/v2/auth",
+        prompt="select_account",
+    )
+    session["google_oauth_state"] = state
+    return redirect(authorization_url)
+
+
+@auth_bp.route("/google/callback")
+def google_callback():
+    """Handle the OAuth callback from Google."""
+    client_id = current_app.config.get("GOOGLE_CLIENT_ID")
+    client_secret = current_app.config.get("GOOGLE_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        flash("Google OAuth is not configured.", "danger")
+        return redirect(url_for("auth.login"))
+
+    state = request.args.get("state")
+    if not state or state != session.get("google_oauth_state"):
+        flash("State mismatch. Authentication failed.", "danger")
+        return redirect(url_for("auth.login"))
+
+    redirect_uri = safe_url_for("auth.google_callback", _external=True)
+    oauth = OAuth2Session(client_id, state=state, redirect_uri=redirect_uri)
+    try:
+        oauth.fetch_token(
+            "https://oauth2.googleapis.com/token",
+            client_secret=client_secret,
+            authorization_response=request.url,
+            timeout=REQUEST_TIMEOUT,
+        )
+    except Exception as exc:
+        flash(f"Error obtaining access token: {exc}", "danger")
+        return redirect(url_for("auth.login"))
+
+    try:
+        userinfo = oauth.get(
+            "https://www.googleapis.com/oauth2/v3/userinfo",
+            timeout=REQUEST_TIMEOUT,
+        ).json()
+    except Exception as exc:
+        flash(f"Error fetching user info: {exc}", "danger")
+        return redirect(url_for("auth.login"))
+
+    google_id = userinfo.get("sub")
+    email = (userinfo.get("email") or "").lower()
+    name = userinfo.get("name")
+    picture = userinfo.get("picture")
+
+    user = None
+    if google_id:
+        user = User.query.filter_by(google_id=google_id).first()
+    if not user and email:
+        user = User.query.filter_by(email=email).first()
+
+    if user:
+        if not user.google_id:
+            user.google_id = google_id
+            db.session.commit()
+    else:
+        username = _generate_username(email)
+        user = User(
+            username=username,
+            email=email,
+            license_agreed=True,
+            email_verified=True,
+            is_admin=False,
+            created_at=datetime.now(UTC),
+            score=0,
+            google_id=google_id,
+            display_name=name,
+            profile_picture=picture,
+        )
+        user.set_password(uuid.uuid4().hex)
+        db.session.add(user)
+        try:
+            db.session.commit()
+        except Exception as exc:
+            db.session.rollback()
+            current_app.logger.error(
+                "Failed to create user via Google: %s", format_db_error(exc)
+            )
+            flash("Error creating user account.", "danger")
+            return redirect(url_for("auth.login"))
+        create_activitypub_actor(user)
+
+    login_user(user)
+    flash("Logged in via Google.", "success")
+    return redirect(url_for("main.index"))
 
 
 def _is_safe_url(target: str | None) -> bool:

--- a/app/config.py
+++ b/app/config.py
@@ -121,6 +121,8 @@ class SocialConfig:
     facebook_page_id: str
     instagram_access_token: str
     instagram_user_id: str
+    google_client_id: str
+    google_client_secret: str
 
 
 @dataclass
@@ -222,6 +224,8 @@ def load_config() -> AppConfig:
             facebook_page_id=_get_env("FACEBOOK_PAGE_ID", ""),
             instagram_access_token=_get_env("INSTAGRAM_ACCESS_TOKEN", ""),
             instagram_user_id=_get_env("INSTAGRAM_USER_ID", ""),
+            google_client_id=_get_env("GOOGLE_CLIENT_ID", ""),
+            google_client_secret=_get_env("GOOGLE_CLIENT_SECRET", ""),
         ),
         push=PushConfig(
             VAPID_PUBLIC_KEY=_get_env("VAPID_PUBLIC_KEY", ""),

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -92,6 +92,7 @@ class User(UserMixin, db.Model):
     mastodon_username = db.Column(db.String(64), nullable=True)
     mastodon_instance = db.Column(db.String(128), nullable=True)
     mastodon_access_token = db.Column(db.String(512), nullable=True)
+    google_id = db.Column(db.String(64), nullable=True)
 
     activitypub_id = db.Column(db.String(256), nullable=True)
     public_key = db.Column(db.Text, nullable=True)

--- a/app/templates/modals/login_modal.html
+++ b/app/templates/modals/login_modal.html
@@ -69,6 +69,9 @@
           <button type="button" class="btn btn-secondary" data-open-modal="mastodonLoginModal">
             Login with Mastodon
           </button>
+          <a href="{{ url_for('auth.google_login') }}" class="btn btn-danger">
+            Login with Google
+          </a>
         </div>
       </form>
 

--- a/docs/GOOGLE.md
+++ b/docs/GOOGLE.md
@@ -1,0 +1,19 @@
+# Google OAuth Setup
+
+This guide explains how to enable Google OAuth login in QuestByCycle.
+
+## Prerequisites
+- A Google Cloud project with the OAuth consent screen configured.
+- Client ID and Client Secret for a web application.
+
+## Configuration
+1. Set the following environment variables:
+   - `GOOGLE_CLIENT_ID`
+   - `GOOGLE_CLIENT_SECRET`
+2. Ensure the authorized redirect URI in the Google Cloud Console matches:
+   ```
+   https://<your-domain>/auth/google/callback
+   ```
+
+## Usage
+After configuration, users can select **Login with Google** from the login modal to authenticate.

--- a/tests/test_google_oauth.py
+++ b/tests/test_google_oauth.py
@@ -1,0 +1,71 @@
+import pytest
+from app import create_app, db
+from app.models.user import User
+from tests.helpers import url_for_path
+from requests_oauthlib import OAuth2Session
+
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "GOOGLE_CLIENT_ID": "cid",
+        "GOOGLE_CLIENT_SECRET": "secret",
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.drop_all()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_google_login_redirect(client):
+    resp = client.get("/auth/login/google", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "accounts.google.com" in resp.headers["Location"]
+    with client.session_transaction() as sess:
+        assert "google_oauth_state" in sess
+
+
+def test_google_callback_creates_user(client, monkeypatch):
+    def fake_fetch_token(self, token_url, client_secret, authorization_response, timeout):
+        return {"access_token": "tok"}
+
+    class FakeResp:
+        def json(self):
+            return {
+                "sub": "123",
+                "email": "foo@example.com",
+                "name": "Foo",
+                "picture": "http://example.com/pic.jpg",
+            }
+
+    def fake_get(self, url, timeout):
+        return FakeResp()
+
+    monkeypatch.setattr(OAuth2Session, "fetch_token", fake_fetch_token)
+    monkeypatch.setattr(OAuth2Session, "get", fake_get)
+
+    with client.session_transaction() as sess:
+        sess["google_oauth_state"] = "abc"
+
+    resp = client.get("/auth/google/callback?state=abc&code=xyz", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith(
+        url_for_path(client.application, "main.index", _external=False)
+    )
+    user = User.query.filter_by(email="foo@example.com").first()
+    assert user is not None
+    assert user.google_id == "123"
+    with client.session_transaction() as sess:
+        assert sess.get("_user_id") == str(user.id)


### PR DESCRIPTION
## Summary
- support Google OAuth2 login alongside existing auth flows
- document Google OAuth configuration and tests

## Testing
- `PYTHONPATH="$PWD" pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1258f14f8832b95ac9cb2591bd37e