### PR TITLE
Fix robots meta on admin pages

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -134,7 +134,7 @@ def user_details(user_id):
     if not user:
         return
 
-    return render_template('user_details.html', user=user)
+    return render_template('user_details.html', user=user, in_admin_dashboard=True)
 
 
 @admin_bp.route('/update_user/<int:user_id>', methods=['POST'])
@@ -271,6 +271,7 @@ def edit_user(user_id):
         user_ips=user_ips,
         games=games,
         timezone_choices=TIMEZONE_CHOICES,
+        in_admin_dashboard=True,
     )
 
 @admin_bp.route('/delete_user/<int:user_id>', methods=['POST'])
@@ -312,7 +313,7 @@ def edit_sponsor(sponsor_id):
                 sponsor.logo = save_sponsor_logo(image_file, old_filename=sponsor.logo)
             except ValueError as e:
                 flash(f"Error saving sponsor logo: {e}", 'error')
-                return render_template('edit_sponsors.html', form=form, sponsor=sponsor, game_id=game_id)
+                return render_template('edit_sponsors.html', form=form, sponsor=sponsor, game_id=game_id, in_admin_dashboard=True)
         
                                       
         sponsor.name = sanitize_html(form.name.data)
@@ -324,7 +325,7 @@ def edit_sponsor(sponsor_id):
         flash('Sponsor updated successfully!', 'success')
         return redirect(url_for('admin.manage_sponsors', game_id=game_id))
 
-    return render_template('edit_sponsors.html', form=form, sponsor=sponsor, game_id=game_id)
+    return render_template('edit_sponsors.html', form=form, sponsor=sponsor, game_id=game_id, in_admin_dashboard=True)
 
 
 
@@ -387,7 +388,7 @@ def manage_sponsors():
                 sponsor.logo = save_sponsor_logo(image_file)
             except ValueError as e:
                 flash(f"Error saving sponsor logo: {e}", 'error')
-                return render_template('manage_sponsors.html', form=form, sponsors=[], game_id=game_id)
+                return render_template('manage_sponsors.html', form=form, sponsors=[], game_id=game_id, in_admin_dashboard=True)
 
         db.session.add(sponsor)
         try:
@@ -402,7 +403,7 @@ def manage_sponsors():
         return redirect(url_for('admin.manage_sponsors', game_id=game_id))
 
     sponsors = Sponsor.query.filter_by(game_id=game_id).all() if game_id else Sponsor.query.all()
-    return render_template('manage_sponsors.html', form=form, sponsors=sponsors, game_id=game_id)
+    return render_template('manage_sponsors.html', form=form, sponsors=sponsors, game_id=game_id, in_admin_dashboard=True)
 
 
 @admin_bp.route('/user_emails', methods=['GET'])
@@ -417,4 +418,4 @@ def user_emails():
         users = User.query.join(user_games).filter(user_games.c.game_id == game.id).all()
         game_email_map[game.title] = [user.email for user in users]
 
-    return render_template('user_emails.html', game_email_map=game_email_map, games=games)
+    return render_template('user_emails.html', game_email_map=game_email_map, games=games, in_admin_dashboard=True)

--- a/app/badges.py
+++ b/app/badges.py
@@ -78,7 +78,7 @@ def create_badge():
         db.session.commit()
         flash('Badge created successfully!', 'success')
         return redirect(url_for('badges.list_badges'))
-    return render_template('create_badge.html', form=form)
+    return render_template('create_badge.html', form=form, in_admin_dashboard=True)
 
 
 @badges_bp.route('', methods=['GET'])

--- a/app/games.py
+++ b/app/games.py
@@ -193,7 +193,7 @@ def create_game():
             process_logo_upload(game)
         except ValueError as error:
             flash(f'Error saving uploaded file: {error}', 'error')
-            return render_template('create_game.html', title='Create Game', form=form)
+            return render_template('create_game.html', title='Create Game', form=form, in_admin_dashboard=True)
 
         db.session.add(game)
         try:
@@ -258,6 +258,7 @@ def update_game(game_id):
                 leaderboard_image=game.leaderboard_image,
                 calendar_service_json_path=game.calendar_service_json_path,
                 logo=game.logo,
+                in_admin_dashboard=True,
             )
 
         try:

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -9,7 +9,7 @@
   <meta name="description" content="QuestByCycle is a photo sharing web platform designed to motivate and engage the cycling community in environmental sustainability. Complete quests, earn badges, and contribute to a greener planet while competing on the leaderboard and connecting with other cyclists.">
   <meta name="keywords" content="cycling, environmental sustainability, gamification, challenges, badges, community, leaderboard">
   <meta name="author" content="QuestByCycle Team">
-  <meta name="robots" content="index, follow">
+  <meta name="robots" content="{{ 'noindex, nofollow' if in_admin_dashboard|default(False) else 'index, follow' }}">
 
   <!-- Required for Safari to recognize the PWA -->
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/tests/test_admin_robots_meta.py
+++ b/tests/test_admin_robots_meta.py
@@ -1,0 +1,54 @@
+import pytest
+from flask_login import login_user
+
+from app import create_app, db
+from app.models.user import User
+
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "MAIL_SERVER": None,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login_as(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    with client.application.test_request_context():
+        login_user(user)
+
+
+def test_admin_dashboard_has_noindex_meta(client):
+    admin = User(
+        username="admin",
+        email="admin@example.com",
+        is_admin=True,
+        license_agreed=True,
+        email_verified=True,
+    )
+    admin.set_password("pw")
+    db.session.add(admin)
+    db.session.commit()
+
+    login_as(client, admin)
+    resp = client.get("/admin/admin_dashboard")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert '<meta name="robots" content="noindex, nofollow">' in html


### PR DESCRIPTION
## Summary
- Avoid search indexing on admin pages by switching robots tag to `noindex, nofollow`
- Propagate `in_admin_dashboard` flag through admin, game, and badge views
- Add regression test confirming admin dashboard sends noindex robots tag

## Testing
- `PYTHONPATH="$PWD" pytest tests/test_admin_robots_meta.py`
- `PYTHONPATH="$PWD" pytest` *(all tests: 89 passed, 98 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a432f87bb4832bbffef1f7d941c8ca