### PR TITLE
Add SRI and security headers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -312,4 +312,18 @@ def create_app(config_overrides=None):
         """Expose the static asset version for cache busting."""
         return dict(asset_version=current_app.config["ASSET_VERSION"])
 
+    @app.after_request
+    def set_security_headers(response):
+        """Apply standard security headers to all responses."""
+        headers = {
+            "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+            "X-Content-Type-Options": "nosniff",
+            "X-Frame-Options": "DENY",
+            "Referrer-Policy": "no-referrer",
+            "Permissions-Policy": "geolocation=(), microphone=(), camera=()",
+        }
+        for key, value in headers.items():
+            response.headers.setdefault(key, value)
+        return response
+
     return app

--- a/app/docs.py
+++ b/app/docs.py
@@ -25,7 +25,11 @@ def redoc():
         <html>
         <head>
             <title>API Docs</title>
-            <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+            <script
+                src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"
+                integrity="sha384-4vOjrBu7SuDWXcAw1qFznVLA/sKL+0l4nn+J1HY8w7cpa6twQEYuh4b0Cwuo7CyX"
+                crossorigin="anonymous"
+            ></script>
         </head>
         <body>
             <redoc spec-url="/docs/openapi.yaml"></redoc>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -461,7 +461,12 @@
 {% endblock %}
 
 {% block extra_styles %}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.6.0/css/all.min.css">
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.6.0/css/all.min.css"
+        integrity="sha384-h/hnnw1Bi4nbpD6kE7nYfCXzovi622sY5WBxww8ARKwpdLj5kUWjRuyiXaD1U2JT"
+        crossorigin="anonymous"
+    >
 {% endblock %}
 
 {% block extra_scripts %}{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -48,8 +48,22 @@
 
   <!-- Load non-critical CSS asynchronously -->
   <link rel="stylesheet" href="{{ url_for('static', filename='dist/style.css', v=asset_version) }}">
-  <link rel="preload" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"></noscript>
+  <link
+    rel="preload"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    as="style"
+    integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+    crossorigin="anonymous"
+    onload="this.onload=null;this.rel='stylesheet'"
+  >
+  <noscript>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    >
+  </noscript>
 
 
   {# Block for page-specific stylesheets #}
@@ -62,9 +76,21 @@
   <meta name="asset-version" content="{{ asset_version }}">
 
   <!-- JavaScript -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.9.0/highlight.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.9.0/highlight.min.js"
+    integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"
+    integrity="sha384-hIoBPJpTUs74ddyc4bFZSM1TVlQDA60VBbJS0oA934VSz82sBx1X7kSx2ATBDIyd"
+    crossorigin="anonymous"
+  ></script>
   <script type="module" src="{{ url_for('static', filename='dist/main.js', v=asset_version) }}"></script>
 </head>
 

--- a/app/templates/submit_photo.html
+++ b/app/templates/submit_photo.html
@@ -6,7 +6,12 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Submit Photo for "{{ quest.title }}"</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='dist/style.css', v=asset_version) }}">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+        crossorigin="anonymous"
+    >
     <script type="module" src="{{ url_for('static', filename='dist/submitPhoto.js', v=asset_version) }}"></script>
     <!-- styles moved to SCSS -->
 </head>
@@ -34,6 +39,10 @@
   
     {% include 'modals/loading_modal.html' %}
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+    crossorigin="anonymous"
+  ></script>
 </body>
 </html>

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -82,3 +82,11 @@ def test_refresh_csrf_cookie_flags(client):
     assert "Secure" in csrf_cookie
     assert "HttpOnly" in csrf_cookie
     assert "SameSite=Strict" in csrf_cookie
+
+
+def test_security_headers_present(client):
+    resp = client.get("/")
+    assert resp.headers["Strict-Transport-Security"] == "max-age=31536000; includeSubDomains"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["Referrer-Policy"] == "no-referrer"


### PR DESCRIPTION
## Summary
- secure CDN assets with SRI hashes
- enforce standard security headers on all responses
- test presence of security headers

## Testing
- `PYTHONPATH="$PWD" pytest` *(fails: 8 failed, 14 passed, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a433024d2c832b8d29fe27c7f55a0f