### PR TITLE
Enforce CSRF token for JSON requests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,7 +18,8 @@ from flask import (
 )
 from flask_login import LoginManager, current_user
 from werkzeug.exceptions import HTTPException
-from flask_wtf.csrf import CSRFProtect, CSRFError
+from flask_wtf.csrf import CSRFProtect, CSRFError, validate_csrf
+from wtforms.validators import ValidationError
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_humanify import Humanify
@@ -223,6 +224,19 @@ def create_app(config_overrides=None):
         app.register_blueprint(docs_bp)
 
     csrf.exempt(ap_bp)
+
+    @app.before_request
+    def enforce_csrf_header() -> None:
+        """Validate CSRF token from headers for JSON requests."""
+        if not app.config.get("WTF_CSRF_ENABLED", True):
+            return
+        if request.method in {"POST", "PUT", "PATCH", "DELETE"} and request.is_json:
+            token = request.headers.get("X-CSRF-Token") or request.headers.get("X-CSRFToken")
+            try:
+                validate_csrf(token)
+            except ValidationError as exc:
+                raise CSRFError(exc.args[0])
+
     login_manager.login_view = "auth.login"
 
     @login_manager.unauthorized_handler

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -454,6 +454,9 @@ sent. Ensure `SECRET_KEY` is defined and access the site using the host specifie
 JavaScript helpers always include CSRF tokens. To disable CSRF checks in a local environment,
 set `WTF_CSRF_ENABLED=false` in your `.env` file.
 
+JSON endpoints must send the token in the `X-CSRF-Token` header. The server rejects
+state-changing JSON requests that omit or provide an incorrect header value.
+
 When `DEBUG=true`, JavaScript helpers skip sending CSRF tokens to simplify local testing.
 CSRF protection on the server is also disabled in this mode so requests succeed without the token.
 

--- a/tests/test_json_csrf.py
+++ b/tests/test_json_csrf.py
@@ -1,0 +1,68 @@
+import pytest
+from datetime import datetime, timezone
+
+from app import create_app, db
+from app.models.user import User
+
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "DEBUG": False,
+        "WTF_CSRF_ENABLED": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def user(app):
+    u = User(
+        username="tester",
+        email="tester@example.com",
+        license_agreed=True,
+        email_verified=True,
+    )
+    u.set_password("secret")
+    u.created_at = datetime.now(timezone.utc)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _login(client, user):
+    token = client.get("/refresh-csrf").get_json()["csrf_token"]
+    resp = client.post(
+        "/auth/login",
+        data={"email": user.email, "password": "secret"},
+        headers={"X-CSRFToken": token, "X-Requested-With": "XMLHttpRequest"},
+    )
+    assert resp.status_code == 200
+    return client.get("/refresh-csrf").get_json()["csrf_token"]
+
+
+def test_json_endpoint_requires_csrf_header(client, user):
+    token = _login(client, user)
+
+    resp = client.post(f"/profile/{user.id}/messages", json={"content": "hi"})
+    assert resp.status_code == 400
+    assert resp.get_json()["message"] == "CSRF token missing or incorrect"
+
+    resp = client.post(
+        f"/profile/{user.id}/messages",
+        json={"content": "hello"},
+        headers={"X-CSRFToken": token},
+    )
+    assert resp.status_code == 201


### PR DESCRIPTION
## Summary
- validate CSRF token from `X-CSRF-Token` headers on JSON mutating requests
- document header requirement for JSON endpoints
- test JSON endpoint rejection when CSRF header missing

## Testing
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a432f20000832b98d3e56e4dda881c