### PR TITLE
Validate media URLs and enforce non-negative params

### DIFF
--- a/app/quests.py
+++ b/app/quests.py
@@ -1106,9 +1106,9 @@ def get_all_submissions():
         limit   (int): Number of submissions to return (default 10).
     """
 
-    game_id = get_int_param("game_id")
-    offset = get_int_param("offset", default=0)
-    limit = get_int_param("limit", default=10)
+    game_id = get_int_param("game_id", min_value=1)
+    offset = get_int_param("offset", default=0, min_value=0)
+    limit = get_int_param("limit", default=10, min_value=1)
 
     if game_id is None:
         return

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -81,8 +81,14 @@ def sanitize_html(html_content: str | None) -> str | None:
     return SANITIZER.sanitize(html_content)
 
 
-def get_int_param(name: str, *, source=None, default: int | None = None) -> int | None:
-    """Safely retrieve an integer parameter from the request.
+def get_int_param(
+    name: str,
+    *,
+    source=None,
+    default: int | None = None,
+    min_value: int | None = None,
+) -> int | None:
+    """Safely retrieve an integer parameter from the request with optional bounds.
 
     Parameters
     ----------
@@ -92,6 +98,9 @@ def get_int_param(name: str, *, source=None, default: int | None = None) -> int 
         The data source, defaults to ``request.args``.
     default:
         Value returned if the parameter is missing or invalid.
+    min_value:
+        Minimum allowed value.  If the parsed integer is below this value,
+        ``default`` is returned instead.
 
     Returns
     -------
@@ -104,9 +113,14 @@ def get_int_param(name: str, *, source=None, default: int | None = None) -> int 
     if raw is None or raw == "":
         return default
     try:
-        return int(raw)
+        value = int(raw)
     except (TypeError, ValueError):
         return default
+
+    if min_value is not None and value < min_value:
+        return default
+
+    return value
 
 
 def format_db_error(error: Exception) -> str:

--- a/app/utils/file_uploads.py
+++ b/app/utils/file_uploads.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import uuid
+from urllib.parse import urlparse
 
 from flask import current_app, url_for
 from google.api_core.exceptions import GoogleAPIError
@@ -421,10 +422,23 @@ def save_submission_video(submission_video_file):
 
 
 def public_media_url(path: str | None) -> str | None:
+    """Return a validated public URL for media assets.
+
+    Absolute URLs must include a scheme and host.  Relative paths are
+    converted to a ``static`` endpoint URL.
+    """
     if not path:
         return None
-    if path.startswith(("http://", "https://", "/static/")):
+
+    if path.startswith("/static/"):
         return path
+
+    if path.startswith(("http://", "https://")):
+        parsed = urlparse(path)
+        if parsed.netloc:
+            return path
+        return None
+
     filename = path.lstrip("/")
     filename = filename.removeprefix("static/")
     return url_for("static", filename=filename)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,6 +41,11 @@ def test_public_media_url_variants(app):
     assert public_media_url("images/foo.jpg") == expect
 
 
+def test_public_media_url_invalid(app):
+    """Invalid absolute media URLs return ``None``."""
+    assert public_media_url("https:///nohost.jpg") is None
+    assert public_media_url("https://") is None
+
 def test_save_submission_video_invalid(app, tmp_path):
     """Uploading an invalid video should raise a ValueError."""
     from io import BytesIO
@@ -187,6 +192,14 @@ def test_get_int_param_parsing(app):
         assert get_int_param('b') is None
         assert get_int_param('c') is None
         assert get_int_param('missing', default=7) == 7
+
+
+def test_get_int_param_non_negative(app):
+    """Values below ``min_value`` should fall back to the default."""
+    with app.test_request_context('/?a=-5&b=10'):
+        assert get_int_param('a', default=0, min_value=0) == 0
+        assert get_int_param('a', min_value=0) is None
+        assert get_int_param('b', min_value=0) == 10
 
 
 def test_delete_media_file_local(app, tmp_path):


### PR DESCRIPTION
## Summary
- add `min_value` bounds to `get_int_param`
- validate host in `public_media_url` and adjust pagination params
- test int bounds and invalid media URLs

## Testing
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4331088ac832ba8e2103a55656c8e