### PR TITLE
Ensure UserIP records are removed when a user is deleted

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -275,11 +275,18 @@ class Notification(db.Model):
 class UserIP(db.Model):
     """Model representing a user's IP address log."""
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user_id = db.Column(
+        db.Integer, db.ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+    )
     ip_address = db.Column(db.String(45), nullable=False)
-    timestamp = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    timestamp = db.Column(
+        db.DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
 
-    user = db.relationship('User', backref='ip_addresses')
+    user = db.relationship(
+        "User",
+        backref=db.backref("ip_addresses", cascade="all, delete-orphan"),
+    )
 
 
 class ActivityStore(db.Model):

--- a/tests/test_user_delete.py
+++ b/tests/test_user_delete.py
@@ -4,7 +4,7 @@ import pytest
 
 from app import create_app, db
 from app.models import followers
-from app.models.user import User, ProfileWallMessage
+from app.models.user import User, ProfileWallMessage, UserIP
 
 
 @pytest.fixture
@@ -96,3 +96,17 @@ def test_delete_user_removes_followers(app, users):
         )
     ).fetchall()
     assert not remaining
+
+
+def test_delete_user_removes_user_ips(app, users):
+    """Deleting a user should remove associated IP address records."""
+    u1, _ = users
+    ip = UserIP(user_id=u1.id, ip_address="127.0.0.1")
+    db.session.add(ip)
+    db.session.commit()
+
+    assert UserIP.query.filter_by(user_id=u1.id).count() == 1
+
+    u1.delete_user()
+
+    assert UserIP.query.filter_by(user_id=u1.id).count() == 0


### PR DESCRIPTION
## Summary
- cascade-delete UserIP rows when their user is removed
- test that account deletion cleans up related UserIP entries

## Testing
- `PYTHONPATH="$PWD" pytest` *(fails: tests/test_manage_badges.py::test_manage_badges_filters_by_game)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf1a61cb0832ba6303b42883c69ec