### PR TITLE
Handle invalid width in image resize

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1013,16 +1013,13 @@ def refresh_csrf():
 def resize_image():
     """Resize an image while honoring the client's accepted formats."""
     image_path = request.args.get('path')
-    width_arg  = request.args.get('width')
+    width = get_int_param("width", min_value=1)
 
-                                                      
-    try:
-        width = int(width_arg)
-    except (TypeError, ValueError):
+    if not image_path:
+        return jsonify({'error': "Invalid request: Missing 'path'"}), 400
+
+    if width is None:
         return jsonify({'error': "Invalid request: 'width' must be a positive integer"}), 400
-
-    if not image_path or width <= 0:
-        return jsonify({'error': "Invalid request: Missing 'path' or 'width'"}), 400
 
     try:
                                                                            
@@ -1038,7 +1035,7 @@ def resize_image():
             return jsonify({'error': 'Invalid file path'}), 400
 
         if not os.path.exists(full_image_path):
-            current_app.logger.error("File not found: %s", full_image_path)
+            current_app.logger.warning("File not found: %s", full_image_path)
             return jsonify({'error': 'File not found'}), 404
 
         with Image.open(full_image_path) as img:

--- a/tests/test_resize_image.py
+++ b/tests/test_resize_image.py
@@ -44,3 +44,17 @@ def test_resize_image_avif(client):
     assert resp.status_code == 200
     assert resp.mimetype == "image/avif"
 
+
+def test_resize_image_invalid_width(client):
+    resp = client.get("/resize_image?path=images/default_badge.png&width=")
+    assert resp.status_code == 400
+    assert resp.get_json()["error"]
+
+
+def test_resize_image_missing_file(client):
+    resp = client.get(
+        "/resize_image?path=images/missing.png&width=50",
+        headers={"Accept": "image/png"},
+    )
+    assert resp.status_code == 404
+


### PR DESCRIPTION
## Summary
- validate width query parameter in `resize_image`
- log missing images at warning level
- add tests for invalid width and missing image path

## Testing
- `PYTHONPATH="$PWD" pytest` *(fails: 43 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf66f4008832b87b2eda2000252a1