### PR TITLE
Limit admin actions to owned games

### DIFF
--- a/app/badges.py
+++ b/app/badges.py
@@ -46,9 +46,6 @@ def allowed_file(filename):
 def create_badge():
     game_id = get_int_param('game_id')
 
-    if not current_user.is_super_admin and not current_user.is_admin_for_game(game_id):
-        abort(403)
-
     quest_categories = (
         db.session.query(Quest.category)
         .filter(Quest.game_id == game_id)
@@ -159,8 +156,6 @@ def manage_badges():
     game_id = get_int_param("game_id")
     if game_id is None:
         game_id = get_int_param("game_id", source=request.form)
-    if not current_user.is_super_admin and not current_user.is_admin_for_game(game_id):
-        abort(403)
 
     category_query = db.session.query(Quest.category).filter(Quest.category.isnot(None))
     if game_id:
@@ -262,6 +257,8 @@ def delete_badge(badge_id: int):
     badge = db.session.get(Badge, badge_id)
     if not badge:
         return jsonify({"success": False, "message": "Badge not found"}), 404
+    if not current_user.is_super_admin and not current_user.is_admin_for_game(badge.game_id):
+        return jsonify({"success": False, "message": "Permission denied"}), 403
     try:
         db.session.delete(badge)
         db.session.commit()
@@ -290,8 +287,6 @@ def get_quest_categories():
 @limiter.limit("50/minute")
 def upload_images():
     game_id = get_int_param('game_id')
-    if not current_user.is_super_admin and not current_user.is_admin_for_game(game_id):
-        abort(403)
 
     uploaded_files = request.files.getlist('file')
     images_folder = os.path.join(current_app.root_path, 'static', 'images', 'badge_images')
@@ -324,8 +319,6 @@ def upload_images():
 @limiter.limit("50/minute")
 def bulk_upload():
     game_id = get_int_param('game_id')
-    if not current_user.is_super_admin and not current_user.is_admin_for_game(game_id):
-        abort(403)
 
     csv_file = request.files.get('csv_file')
     image_files = request.files.getlist('image_files')

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -6,9 +6,9 @@ from flask_login import current_user
 def require_admin(func):
     """Allow access only to admins or super admins.
 
-    When a ``game_id`` argument is present, non-super admins must be an
-    administrator for that specific game. This helps ensure admins cannot
-    manage games they do not control.
+    When a ``game_id`` is supplied through route parameters, query strings, or
+    form data, non‑super admins must be administrators for that specific
+    game. This helps ensure admins cannot manage games they do not control.
     """
 
     @wraps(func)
@@ -18,8 +18,13 @@ def require_admin(func):
             return redirect(url_for('main.index'))
 
         if not current_user.is_super_admin:
-            game_id = kwargs.get('game_id') or request.view_args.get('game_id')
-            if game_id and not current_user.is_admin_for_game(game_id):
+            game_id = (
+                kwargs.get('game_id')
+                or request.view_args.get('game_id')
+                or request.args.get('game_id')
+                or request.form.get('game_id')
+            )
+            if game_id and not current_user.is_admin_for_game(int(game_id)):
                 flash('Access denied: You do not have permission for this game.', 'error')
                 return redirect(url_for('main.index'))
 

--- a/app/templates/user_management.html
+++ b/app/templates/user_management.html
@@ -24,7 +24,9 @@
             <div class="filter-section">
                 <label for="gameFilter">Filter by Game:</label>
                 <select id="gameFilter" class="form-control">
+                    {% if current_user.is_super_admin %}
                     <option value="">All Games</option>
+                    {% endif %}
                     {% for game in games %}
                     <option value="{{ game.id }}" {% if selected_game and selected_game.id == game.id %} selected {% endif %}>
                         {{ game.title }}
@@ -43,7 +45,9 @@
                             <th>Email</th>
                             <th>Score Per Game</th>
                             <th>Games Joined</th>
+                            {% if current_user.is_super_admin %}
                             <th>Actions</th>
+                            {% endif %}
                         </tr>
                     </thead>
                     <tbody>
@@ -66,9 +70,11 @@
                                     {% endfor %}
                                 </ul>
                             </td>
+                            {% if current_user.is_super_admin %}
                             <td>
                                 <a href="{{ url_for('admin.edit_user', user_id=user.id) }}" class="btn btn-info btn-sm">View Details</a>
                             </td>
+                            {% endif %}
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/tests/test_admin_separation.py
+++ b/tests/test_admin_separation.py
@@ -1,0 +1,87 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+from flask_login import login_user
+
+from app import create_app, db
+from app.models import Game, Badge, User
+
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "MAIL_SERVER": None,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login_as(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    with client.application.test_request_context():
+        login_user(user)
+
+
+def create_admin(username):
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        is_admin=True,
+        license_agreed=True,
+        email_verified=True,
+    )
+    user.set_password("pw")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def create_game(title, admin):
+    game = Game(
+        title=title,
+        start_date=datetime.now(timezone.utc) - timedelta(days=1),
+        end_date=datetime.now(timezone.utc) + timedelta(days=1),
+        admin_id=admin.id,
+        timezone="UTC",
+    )
+    game.admins.append(admin)
+    db.session.add(game)
+    db.session.commit()
+    return game
+
+
+def test_admin_cannot_delete_other_games_badge(client):
+    admin1 = create_admin("admin1")
+    admin2 = create_admin("admin2")
+
+    game1 = create_game("Game 1", admin1)
+    game2 = create_game("Game 2", admin2)
+
+    foreign_badge = Badge(name="B", description="desc", game_id=game2.id)
+    own_badge = Badge(name="Own", description="desc", game_id=game1.id)
+    db.session.add_all([foreign_badge, own_badge])
+    db.session.commit()
+
+    login_as(client, admin1)
+
+    resp = client.delete(f"/badges/delete/{foreign_badge.id}")
+    assert resp.status_code == 403
+    assert Badge.query.get(foreign_badge.id) is not None
+
+    resp = client.delete(f"/badges/delete/{own_badge.id}")
+    assert resp.status_code == 200
+    assert Badge.query.get(own_badge.id) is None

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -1,0 +1,117 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+from flask_login import login_user
+
+from app import create_app, db
+from app.models import Game, User
+
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "MAIL_SERVER": None,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login_as(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    with client.application.test_request_context():
+        login_user(user)
+
+
+def create_admin(username):
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        is_admin=True,
+        license_agreed=True,
+        email_verified=True,
+    )
+    user.set_password("pw")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def create_player(username):
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        license_agreed=True,
+        email_verified=True,
+    )
+    user.set_password("pw")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def create_game(title, admin):
+    game = Game(
+        title=title,
+        start_date=datetime.now(timezone.utc) - timedelta(days=1),
+        end_date=datetime.now(timezone.utc) + timedelta(days=1),
+        admin_id=admin.id,
+        timezone="UTC",
+    )
+    game.admins.append(admin)
+    db.session.add(game)
+    db.session.commit()
+    return game
+
+
+def test_admin_sees_only_their_game_users(client):
+    admin1 = create_admin("admin1")
+    admin2 = create_admin("admin2")
+    player1 = create_player("player1")
+    player2 = create_player("player2")
+
+    game1 = create_game("Game 1", admin1)
+    game2 = create_game("Game 2", admin2)
+
+    player1.participated_games.append(game1)
+    player2.participated_games.append(game2)
+    db.session.commit()
+
+    login_as(client, admin1)
+
+    resp = client.get(f"/admin/user_management/game/{game1.id}")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "player1@example.com" in html
+    assert "player2@example.com" not in html
+
+    resp = client.get(f"/admin/user_management/game/{game2.id}")
+    assert resp.status_code == 302
+
+
+def test_admin_cannot_delete_user(client):
+    admin = create_admin("admin")
+    player = create_player("player")
+    game = create_game("Game", admin)
+    player.participated_games.append(game)
+    db.session.commit()
+
+    login_as(client, admin)
+
+    resp = client.post(f"/admin/delete_user/{player.id}")
+    assert resp.status_code == 302
+    assert User.query.get(player.id) is not None
+


### PR DESCRIPTION
## Summary
- limit user management views to games the admin controls
- hide cross-game options and super-admin actions from standard admins
- test that game admins only see their own users and cannot delete them

## Testing
- `pip install -e .` *(fails: RuntimeError: Building a package is not possible in non-package mode)*
- `pip install Flask Flask-SQLAlchemy Flask-Login`
- `PYTHONPATH="$PWD" pytest` *(fails: ModuleNotFoundError: No module named 'flask_wtf')*


------
https://chatgpt.com/codex/tasks/task_e_68ac01f6c778832ba12d12513949d4fd