### PR TITLE
Fix Google OAuth token exchange

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -484,20 +484,25 @@ def google_callback():
                 flash("Your sign-in session expired. Please try again.", "warning")
                 return redirect(url_for("auth.google_login"))
 
-        # Be explicit with Google: pass the token URL positionally, and include redirect_uri & client_id.
+        # Be explicit with Google: pass the authorization code and include redirect_uri & client_id.
         token = oauth.fetch_token(
             "https://oauth2.googleapis.com/token",
+            code=request.args.get("code"),
             client_secret=client_secret,
-            authorization_response=request.url,
             redirect_uri=redirect_uri,   # must match the auth request exactly
             client_id=client_id,         # send explicitly
             include_client_id=True,      # ensure client_id is in the body
             timeout=REQUEST_TIMEOUT,
             **(
-                {"code_verifier": (code_verifier_value.decode()
-                                   if isinstance(code_verifier_value, (bytes, bytearray))
-                                   else str(code_verifier_value))}
-                if use_pkce else {}
+                {
+                    "code_verifier": (
+                        code_verifier_value.decode()
+                        if isinstance(code_verifier_value, (bytes, bytearray))
+                        else str(code_verifier_value)
+                    )
+                }
+                if use_pkce
+                else {}
             ),
         )
         current_app.logger.info("Google OAuth token exchange OK for state=%s", state)

--- a/tests/test_google_oauth.py
+++ b/tests/test_google_oauth.py
@@ -13,6 +13,7 @@ def app():
         "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
         "GOOGLE_CLIENT_ID": "cid",
         "GOOGLE_CLIENT_SECRET": "secret",
+        "OAUTH_USE_PKCE": "false",
     })
     ctx = app.app_context()
     ctx.push()
@@ -39,10 +40,13 @@ def test_google_login_redirect(client):
 
 
 def test_google_callback_creates_user(client, monkeypatch):
-    def fake_fetch_token(self, token_url, client_secret, authorization_response, timeout):
+    def fake_fetch_token(self, token_url, *args, **kwargs):
         return {"access_token": "tok"}
 
     class FakeResp:
+        def raise_for_status(self):
+            pass
+
         def json(self):
             return {
                 "sub": "123",


### PR DESCRIPTION
## Summary
- Pass explicit authorization code when exchanging Google OAuth tokens
- Expand test stubs and disable PKCE for simpler Google OAuth testing

## Testing
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad2a7f15ec832ba40927f341a75ec6