### PR TITLE
Fix Google OAuth token exchange

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -484,14 +484,16 @@ def google_callback():
                 flash("Your sign-in session expired. Please try again.", "warning")
                 return redirect(url_for("auth.google_login"))
 
-        # Be explicit with Google: pass the authorization code and include redirect_uri & client_id.
+        # Explicitly pass the authorization code and redirect URI. `client_id` is
+        # already bound to the session and does not need to be supplied again.
+        # Including it in the body can cause Google to reject the request with
+        # an `invalid_client` error.  Rely on HTTP basic auth instead and only
+        # send the PKCE verifier when applicable.
         token = oauth.fetch_token(
             "https://oauth2.googleapis.com/token",
             code=request.args.get("code"),
             client_secret=client_secret,
             redirect_uri=redirect_uri,   # must match the auth request exactly
-            client_id=client_id,         # send explicitly
-            include_client_id=True,      # ensure client_id is in the body
             timeout=REQUEST_TIMEOUT,
             **(
                 {

--- a/tests/test_google_oauth.py
+++ b/tests/test_google_oauth.py
@@ -41,6 +41,15 @@ def test_google_login_redirect(client):
 
 def test_google_callback_creates_user(client, monkeypatch):
     def fake_fetch_token(self, token_url, *args, **kwargs):
+        # The OAuth session already knows the client ID; the callback should
+        # not redundantly supply it or the `include_client_id` flag. Doing so
+        # can trigger an `invalid_client` error from Google.
+        assert "client_id" not in kwargs
+        assert "include_client_id" not in kwargs
+        # The client secret is still required for the server-side exchange.
+        assert kwargs.get("client_secret") == "secret"
+        # Ensure the redirect URI is explicitly passed through.
+        assert "redirect_uri" in kwargs
         return {"access_token": "tok"}
 
     class FakeResp:


### PR DESCRIPTION
## Summary
- avoid sending client_id twice during Google OAuth token exchange
- cover callback token exchange parameters with a unit test

## Testing
- `PYTHONPATH="$PWD" pytest` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2f3eaeb0832bb88d2ae7deaa5fd5