### PR TITLE
feat: add shareable album route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1226,6 +1226,12 @@ def share_target_handler():
     return redirect(url_for('main.index'))
 
 
+@main_bp.route('/album/<int:game_id>')
+def album(game_id):
+    """Redirect to the index page and open the album for the given game."""
+    return redirect(url_for('main.index', game_id=game_id, album=1))
+
+
 @main_bp.route('/.well-known/assetlinks.json')
 def assetlinks():
     """Serve digital asset links for TWA validation."""

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -122,7 +122,7 @@
                                                     <span>{{ game.title }}</span>
                                                 </strong>
                                                 <span class="activity-message">
-                                                    <a href="#" role="button"
+                                                    <a href="{{ url_for('main.album', game_id=game.id) }}" role="button"
                                                         class="text-decoration-underline"
                                                         id="viewAlbumLink"
                                                         data-open-all-submissions
@@ -130,8 +130,8 @@
                                                         onclick="return window.__openAlbumFromLink ? __openAlbumFromLink(this, event) : false;">
                                                          View Album
                                                      </a>
-                                                </span>
-                                            </div>
+                                               </span>
+                                           </div>
                                             {% endif %}
                                             {% set pinned_activities = activities | selectattr('is_pinned') | list %}
                                             {% if pinned_activities %}
@@ -732,11 +732,24 @@
         return false;
       }
     }
+    function __openAlbumOnQuery(){
+      try {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('album') === '1') {
+          const gid = params.get('game_id');
+          openAlbum(gid);
+        }
+      } catch {}
+    }
 
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', __initAlbumWiring);
+      document.addEventListener('DOMContentLoaded', function(){
+        __initAlbumWiring();
+        __openAlbumOnQuery();
+      });
     } else {
       __initAlbumWiring();
+      __openAlbumOnQuery();
     }
   })();
 </script>

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -10,6 +10,7 @@ Welcome to QuestByCycle, a gamified bicycling platform! This guide will help you
 2. [Navigating the Platform](#navigating-the-platform)
     - [Dashboard Overview](#dashboard-overview)
     - [Game Participation](#game-participation)
+    - [Viewing Game Albums](#viewing-game-albums)
 3. [Completing Quests](#completing-quests)
     - [Finding Quests](#finding-quests)
     - [Quest Verification](#quest-verification)
@@ -69,6 +70,18 @@ The dashboard is your central hub for accessing games, quests, and community fea
 **Leaving a Game**:
 1. **Access Your Games**: Go to the "Games" section and find the game you want to leave.
 2. **Leave the Game**: Click on "Leave Game" and confirm your decision.
+
+### Viewing Game Albums
+
+Each game stores participants' quest submissions in an album.
+Open an album from the dashboard's "View Album" link or directly via:
+
+```
+/album/<game_id>
+```
+
+Replace `<game_id>` with the numeric ID of the game.  
+The album opens automatically when visiting this URL, making it easy to share.
 
 ## Completing Quests
 

--- a/tests/test_album_route.py
+++ b/tests/test_album_route.py
@@ -1,0 +1,26 @@
+import pytest
+from app import create_app
+
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_album_route_redirects(client):
+    resp = client.get('/album/42')
+    assert resp.status_code == 302
+    assert '/42?album=1' in resp.headers['Location']
+


### PR DESCRIPTION
## Summary
- expose `/album/<game_id>` route redirecting to a game's album
- allow index page to auto-open the album via `?album=1`
- document and test the new shareable album link

## Testing
- `npm install`
- `npm run build`
- `PYTHONPATH="$PWD" pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbcfdfdf28832bb934167e1db1dd8f