### PR TITLE
Handle invalid like responses in album modal

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -699,13 +699,19 @@
             method: liked ? "DELETE" : "POST",
             headers: {
               "Content-Type": "application/json",
+              Accept: "application/json",
               "X-CSRFToken": csrf
             },
             credentials: "same-origin"
           })
-            .then(r => r.json())
-            .then(d => {
-              if (!d.success) throw new Error("Like failed");
+            .then(async r => {
+              const data = await r.json().catch(() => ({}));
+              return { status: r.status, json: data };
+            })
+            .then(({ status, json: d }) => {
+              if (status !== 200 || !d.success) {
+                throw new Error(d.message || d.error || "Like failed");
+              }
               likeCount.textContent = d.like_count;
               likeBtn.classList.toggle("active", d.liked);
               s.like_count = d.like_count;


### PR DESCRIPTION
## Summary
- avoid JSON parsing errors when liking an album item by checking response status and adding Accept header

## Testing
- `npm run build`
- `PYTHONPATH="$PWD" pytest` *(fails: ModuleNotFoundError: No module named 'qrcode')*


------
https://chatgpt.com/codex/tasks/task_e_68bcdcbd2c40832bb4d394b929dcc35a