### PR TITLE
feat: require album access code for public viewers

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -130,6 +130,9 @@
                                                         onclick="return window.__openAlbumFromLink ? __openAlbumFromLink(this, event) : false;">
                                                          View Album
                                                      </a>
+                                                     {% if current_user.is_authenticated %}
+                                                     <span class="album-code">Code: {{ game.album_code }}</span>
+                                                     {% endif %}
                                                </span>
                                            </div>
                                             {% endif %}
@@ -496,12 +499,14 @@
 <script>
   (function(){
     const PLACEHOLDER_IMAGE = document.querySelector('meta[name="placeholder-image"]').getAttribute('content');
+    const IS_AUTHENTICATED = {{ 'true' if current_user.is_authenticated else 'false' }};
     let __albumLoaded = [];
     let __page = 0;
     let __gameId = null;
     let __hasMore = false;
     let __loading = false;
     let __gameQuests = null;
+    let __albumCode = null;
 
     function openModalFallback(modalId){
       const modal = document.getElementById(modalId);
@@ -537,9 +542,16 @@
       if (__loading) return Promise.resolve(0);
       __loading = true;
       const offset = __page * 10;
-      const url = `/quests/quest/all_submissions?game_id=${encodeURIComponent(__gameId)}&offset=${offset}&limit=10`;
+      let url = `/quests/quest/all_submissions?game_id=${encodeURIComponent(__gameId)}&offset=${offset}&limit=10`;
+      if (__albumCode) url += `&album_code=${encodeURIComponent(__albumCode)}`;
       return fetch(url, { credentials: 'same-origin', cache: 'no-store', headers:{'Accept':'application/json'} })
-        .then(r => r.json())
+        .then(async r => {
+          if (!r.ok) {
+            const err = await r.json().catch(() => ({}));
+            throw new Error(err.error || 'Failed to load submissions.');
+          }
+          return r.json();
+        })
         .then(json => {
           if(!json || !Array.isArray(json.submissions)) throw new Error('Bad response');
           __hasMore = !!json.has_more;
@@ -548,7 +560,7 @@
           __page += 1;
           return __albumLoaded.length - before;
         })
-        .catch(err => { console.error('Album fetch failed:', err); alert('Failed to load submissions.'); return 0; })
+        .catch(err => { console.error('Album fetch failed:', err); alert(err.message); return 0; })
         .finally(() => { __loading = false; });
     }
 
@@ -629,6 +641,14 @@
       __albumLoaded = [];
       __page = 0;
       __gameId = gid;
+      if (!IS_AUTHENTICATED) {
+        if (!__albumCode) {
+          __albumCode = window.prompt('Enter album code');
+        }
+        if (!__albumCode) {
+          return;
+        }
+      }
       fetchPage().then(loaded => {
         if ((__albumLoaded.length||0) > 0) {
           openSubmissionDetail(0);

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -80,8 +80,10 @@ Open an album from the dashboard's "View Album" link or directly via:
 /album/<game_id>
 ```
 
-Replace `<game_id>` with the numeric ID of the game.  
-The album opens automatically when visiting this URL, making it easy to share.
+Replace `<game_id>` with the numeric ID of the game.
+Authenticated players will see a four-character album code next to the "View Album" link.
+Share this code along with the URL. Visitors who are not logged in will be
+prompted to enter the code before the album loads.
 
 ## Completing Quests
 

--- a/tests/test_album_code_access.py
+++ b/tests/test_album_code_access.py
@@ -1,0 +1,65 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from app import create_app, db
+from app.models.game import Game
+from app.models.quest import Quest, QuestSubmission
+from app.models.user import User
+
+
+@pytest.fixture
+def app():
+    app = create_app({
+        "TESTING": True,
+        "WTF_CSRF_ENABLED": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "MAIL_SERVER": None,
+    })
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_album_requires_code(client, app):
+    with app.app_context():
+        admin = User(username="admin", email="admin@example.com", license_agreed=True)
+        admin.set_password("pw")
+        db.session.add(admin)
+        db.session.commit()
+
+        game = Game(
+            title="Game",
+            start_date=datetime.now(timezone.utc) - timedelta(days=1),
+            end_date=datetime.now(timezone.utc) + timedelta(days=1),
+            admin_id=admin.id,
+        )
+        db.session.add(game)
+        db.session.commit()
+
+        quest = Quest(title="Quest", points=1, game=game)
+        db.session.add(quest)
+        db.session.commit()
+
+        submission = QuestSubmission(quest_id=quest.id, user_id=admin.id)
+        db.session.add(submission)
+        db.session.commit()
+
+        gid = game.id
+        code = game.album_code
+
+    resp = client.get(f"/quests/quest/all_submissions?game_id={gid}")
+    assert resp.status_code == 403
+
+    resp = client.get(f"/quests/quest/all_submissions?game_id={gid}&album_code={code}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["submissions"]) == 1


### PR DESCRIPTION
## Summary
- add `album_code` to games with automatic generation
- require album code for unauthenticated album access and prompt code in UI
- document how to share albums with 4-character codes

## Testing
- `PYTHONPATH="$PWD" pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3da92680832b9366a0267af028fd